### PR TITLE
DFI-1896 Add CT_ENROLLED success case to pattern match

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -72,9 +72,9 @@ class FrontendAppConfig @Inject(config: Configuration) extends ServicesConfig(co
   def grsRetrieveResultUrl(journeyId: String): String =
     s"$incorporatedEntityIdentificationHost/incorporated-entity-identification/api/journey/$journeyId"
 
-  lazy val grsCallback: String = s"$host/obligations/enrolment/isa/incorporated-identity-callback"
+  lazy val grsCallback: String = "/obligations/enrolment/isa/incorporated-identity-callback"
 
-  lazy val accessibilityStatementUrl = s"/accessibility-statement/disa-registration-frontend"
+  lazy val accessibilityStatementUrl = "/accessibility-statement/disa-registration-frontend"
 
   lazy val maxLiaisonOfficers: Int = getInt("maxLiaisonOfficers")
   lazy val maxSignatories: Int     = getInt("max-signatories")

--- a/app/controllers/GrsController.scala
+++ b/app/controllers/GrsController.scala
@@ -17,7 +17,8 @@
 package controllers
 
 import controllers.actions.*
-import models.grs.{BvFail, BvPass, GRSResponse, RegisteredStatus}
+import handlers.ErrorHandler
+import models.grs.*
 import models.journeydata.BusinessVerification
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -26,7 +27,7 @@ import services.{BusinessVerificationLockoutService, GrsService, JourneyAnswersS
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class GrsController @Inject() (
   override val messagesApi: MessagesApi,
@@ -34,6 +35,7 @@ class GrsController @Inject() (
   getData: DataRetrievalAction,
   journeyAnswersService: JourneyAnswersService,
   grsService: GrsService,
+  errorHandler: ErrorHandler,
   businessVerificationLockoutService: BusinessVerificationLockoutService,
   val controllerComponents: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
@@ -53,7 +55,7 @@ class GrsController @Inject() (
 
         (verificationPassed, registrationPassed) match {
 
-          case (Some(BvPass), true) =>
+          case (Some(BvPass), true) | (Some(CtEnrolled), true) =>
             journeyAnswersService
               .update(businessVerification, request.groupId, request.credentials.providerId)
               .map { _ =>
@@ -71,14 +73,13 @@ class GrsController @Inject() (
 
               case None =>
                 logger.warn(s"[BV] Missing UTR on failed verification for groupId=${request.groupId}")
-                Future.successful(
-                  Redirect(routes.StartController.onPageLoad())
-                )
+                errorHandler.internalServerError
             }
           case _                                                                 =>
-            Future.successful(
-              Redirect(routes.StartController.onPageLoad())
-            )
+            val bvStatus = grsResponse.businessVerificationStatus.map(status => s" BV Status: [$status]")
+            logger
+              .warn(s"Failure from GRS/BV. Registration status: [${grsResponse.businessRegistrationStatus}]$bvStatus")
+            errorHandler.internalServerError
         }
       }
     }

--- a/app/models/grs/GrsCreateJourneyRequest.scala
+++ b/app/models/grs/GrsCreateJourneyRequest.scala
@@ -17,6 +17,7 @@
 package models.grs
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.play.bootstrap.binders.OnlyRelative
 
 case class GrsCreateJourneyRequest(
   continueUrl: String,
@@ -26,7 +27,11 @@ case class GrsCreateJourneyRequest(
   regime: String,
   accessibilityUrl: String,
   labels: Option[Labels]
-)
+) {
+  require(OnlyRelative.applies(continueUrl), "continueUrl must be relative")
+  require(OnlyRelative.applies(signOutUrl), "signOutUrl must be relative")
+  require(OnlyRelative.applies(accessibilityUrl), "accessibilityUrl must be relative")
+}
 
 object GrsCreateJourneyRequest {
   implicit val format: OFormat[GrsCreateJourneyRequest] = Json.format[GrsCreateJourneyRequest]

--- a/app/services/GrsService.scala
+++ b/app/services/GrsService.scala
@@ -40,7 +40,7 @@ class GrsService @Inject() (grsConnector: GrsConnector, appConfig: FrontendAppCo
       continueUrl = appConfig.grsCallback,
       businessVerificationCheck = true,
       deskProServiceId = "deskProServiceId",
-      signOutUrl = appConfig.host + controllers.auth.routes.AuthController.signOut().url,
+      signOutUrl = controllers.auth.routes.AuthController.signOut().url,
       regime =
         "ISA", // TODO: waiting on confirmation for this only options according to docs are VATC/PPT but seems to work fine with ISA locally
       accessibilityUrl = appConfig.accessibilityStatementUrl,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,8 +61,8 @@ microservice {
       incorporated-entity-identification-frontend {
          protocol = http
          host = localhost
-         port = 9718
-         url = "http://localhost:9718"
+         port = 1203
+         url = "http://localhost:1203"
       }
       accessibility-statement {
         service-path = "/disa-registration-frontend"

--- a/it/test/controllers/GrsControllerISpec.scala
+++ b/it/test/controllers/GrsControllerISpec.scala
@@ -16,8 +16,6 @@
 
 package controllers
 
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.verify
 import org.mongodb.scala.*
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.FakeRequest

--- a/it/test/controllers/GrsControllerISpec.scala
+++ b/it/test/controllers/GrsControllerISpec.scala
@@ -16,6 +16,8 @@
 
 package controllers
 
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.verify
 import org.mongodb.scala.*
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.FakeRequest
@@ -137,7 +139,7 @@ class GrsControllerISpec extends BaseIntegrationSpec with CommonStubs with Scala
       isLockedOut shouldBe true
     }
 
-    "redirect to Start when verification FAILS but UTR is missing (no lockout)" in {
+    "show error page when verification FAILS but UTR is missing (no lockout)" in {
 
       val journeyData =
         s"""{ "groupId": "$testGroupId" }"""
@@ -155,9 +157,7 @@ class GrsControllerISpec extends BaseIntegrationSpec with CommonStubs with Scala
           .withSession(SessionKeys.authToken -> "Bearer mock-bearer-token")
       ).get
 
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe
-        Some(routes.StartController.onPageLoad().url)
+      status(result) shouldBe INTERNAL_SERVER_ERROR
 
       isLockedOut shouldBe false
     }
@@ -180,9 +180,7 @@ class GrsControllerISpec extends BaseIntegrationSpec with CommonStubs with Scala
           .withSession(SessionKeys.authToken -> "Bearer mock-bearer-token")
       ).get
 
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe
-        Some(routes.StartController.onPageLoad().url)
+      status(result) shouldBe INTERNAL_SERVER_ERROR
 
       isLockedOut shouldBe false
     }
@@ -205,9 +203,7 @@ class GrsControllerISpec extends BaseIntegrationSpec with CommonStubs with Scala
           .withSession(SessionKeys.authToken -> "Bearer mock-bearer-token")
       ).get
 
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe
-        Some(routes.StartController.onPageLoad().url)
+      status(result) shouldBe INTERNAL_SERVER_ERROR
 
       isLockedOut shouldBe false
     }
@@ -230,9 +226,7 @@ class GrsControllerISpec extends BaseIntegrationSpec with CommonStubs with Scala
           .withSession(SessionKeys.authToken -> "Bearer mock-bearer-token")
       ).get
 
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe
-        Some(routes.StartController.onPageLoad().url)
+      status(result) shouldBe INTERNAL_SERVER_ERROR
 
       isLockedOut shouldBe false
     }

--- a/test/controllers/grs/GrsControllerSpec.scala
+++ b/test/controllers/grs/GrsControllerSpec.scala
@@ -120,7 +120,7 @@ class GrsControllerSpec extends SpecBase {
         }
       }
 
-      "must redirect to Start when business verification fails but UTR is missing" in {
+      "must show error page when business verification fails but UTR is missing" in {
 
         val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
 
@@ -136,15 +136,15 @@ class GrsControllerSpec extends SpecBase {
         running(application) {
           val result = route(application, fakeRequest).value
 
-          status(result)                 shouldBe SEE_OTHER
-          redirectLocation(result).value shouldBe controllers.routes.StartController.onPageLoad().url
+          status(result) shouldBe INTERNAL_SERVER_ERROR
+          verify(mockErrorHandler).internalServerError(any)
 
           verify(mockBvLockoutService, Mockito.never())
             .lockout(any[String], any[String])
         }
       }
 
-      "must redirect to Start when no business registration/verification data present" in {
+      "must show error page when no business registration/verification data present" in {
         val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
         val grsResponse = baseGRSResponse(
           businessRegistrationStatus = FailedStatus,
@@ -177,12 +177,12 @@ class GrsControllerSpec extends SpecBase {
         running(application) {
           val result = route(application, fakeRequest).value
 
-          status(result)                 shouldBe SEE_OTHER
-          redirectLocation(result).value shouldBe controllers.routes.StartController.onPageLoad().url
+          status(result) shouldBe INTERNAL_SERVER_ERROR
+          verify(mockErrorHandler).internalServerError(any)
         }
       }
 
-      "must redirect to Start when business registration fails" in {
+      "must show error page when business registration fails" in {
         val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
         val grsResponse = baseGRSResponse(businessRegistrationStatus = FailedStatus)
 
@@ -212,8 +212,8 @@ class GrsControllerSpec extends SpecBase {
         running(application) {
           val result = route(application, fakeRequest).value
 
-          status(result)                 shouldBe SEE_OTHER
-          redirectLocation(result).value shouldBe controllers.routes.StartController.onPageLoad().url
+          status(result) shouldBe INTERNAL_SERVER_ERROR
+          verify(mockErrorHandler).internalServerError(any)
         }
       }
 

--- a/test/models/GrsCreateJourneyRequestSpec.scala
+++ b/test/models/GrsCreateJourneyRequestSpec.scala
@@ -22,7 +22,7 @@ import utils.JsonFormatSpec
 class GrsCreateJourneyRequestSpec extends JsonFormatSpec[GrsCreateJourneyRequest] {
 
   val testJourneyRequest: GrsCreateJourneyRequest = GrsCreateJourneyRequest(
-    continueUrl = "http://localhost/continue",
+    continueUrl = "/continue",
     businessVerificationCheck = true,
     deskProServiceId = "deskProId",
     signOutUrl = "/some/url",
@@ -35,7 +35,7 @@ class GrsCreateJourneyRequestSpec extends JsonFormatSpec[GrsCreateJourneyRequest
 
   override val expectedJsonFromWrites: JsValue = Json.parse("""
     {
-      "continueUrl": "http://localhost/continue",
+      "continueUrl": "/continue",
       "businessVerificationCheck": true,
       "deskProServiceId": "deskProId",
       "signOutUrl": "/some/url",


### PR DESCRIPTION
For now we will show an error page for these non-BV-fail kickout cases, and discussion to be had with UCD about making a unique page to follow.

Changes to the frontend and stub are based on the following info.


### Kickouts
So apart from BV fail x5 when a lockout occurs (accounted for with existing page and code), there are two GRS/BV kickout scenarios that can happen for different reasons:


 - The call to register as a business partner (and receive the BP Id) fails at the end of the journey, returning to us with a REGISTRATION_FAILED status.
 - If an IM that is a registered society does not have an enrolment for CT, does not enter a CT UTR (this is optional field for Registered societies) and HMRC has no known CT UTR then the user is passed to us. This scenario is present [here](https://app.diagrams.net/#G1Z3sx38cPccBs2HFfbgmfRkGY5o69E7Ou#%7B%22pageId%22%3A%22FgDZ-AIpX9OcnDoo5h_3%22%7D) and [here](https://confluence.tools.tax.service.gov.uk/spaces/GG/pages/409240835/Registered+society+responses). It is marked as under review. From reading around about the likelihood of a Reigstered society that manages ISAs not having a CT UTR or being unknown to HMRC, I don't think we should be investing time in a unique kickout screen for this.


Currently, we handle both of these scenarios funneling them into a catch-all that redirects the user to the start page, and so back into GRS/BV.

### Success cases
In researching the above, I have discovered that we have not accounted for another possible success scenario.

This scenario is when the user has an IR-CT enrolment, this fast-tracks them to register with ETMP as a business partner, skipping the BV journey entirely, and returning them to us with a business verification status of CT_ENROLLED. See the first case [here](https://confluence.tools.tax.service.gov.uk/spaces/GG/pages/300449965/UK+company+responses).