### PR TITLE
DFI-2112 Task List – ISA Manager Enrolment Landing Page and Task Status Behaviour

### DIFF
--- a/app/assets/javascript/print-link.js
+++ b/app/assets/javascript/print-link.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const printLinks = document.querySelectorAll('.app-print-link')
+
+  printLinks.forEach(function (link) {
+    link.addEventListener('click', function (event) {
+      event.preventDefault()
+      window.print()
+    })
+  })
+})

--- a/app/controllers/GrsController.scala
+++ b/app/controllers/GrsController.scala
@@ -90,8 +90,8 @@ class GrsController @Inject() (
   ): BusinessVerification = {
     val verificationPassed: Option[Boolean] =
       grs.businessVerificationStatus.map {
-        case BvPass => true
-        case _      => false
+        case BvPass | CtEnrolled => true
+        case _                   => false
       }
 
     val registrationPassed: Option[Boolean] =

--- a/app/controllers/SubmissionCyaController.scala
+++ b/app/controllers/SubmissionCyaController.scala
@@ -20,9 +20,9 @@ import controllers.actions.*
 import controllers.routes.TaskListController
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.User
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.checkAnswers.submission.SubmissionCyaViewModel
+import viewmodels.tasklist.TaskListViewModel
 import views.html.SubmissionCyaView
 
 import javax.inject.Inject
@@ -39,7 +39,7 @@ class SubmissionCyaController @Inject() (
 
   def onPageLoad(): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
-      val canSubmit = request.credentialRole == User
+      val canSubmit = TaskListViewModel.canSubmitAnswers(request.journeyData, request.credentialRole)
 
       if (canSubmit) Ok(view(SubmissionCyaViewModel(request.journeyData)))
       else Redirect(TaskListController.onPageLoad())
@@ -47,7 +47,7 @@ class SubmissionCyaController @Inject() (
 
   def onSubmit(): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
-      if (request.credentialRole == User) {
+      if (TaskListViewModel.canSubmitAnswers(request.journeyData, request.credentialRole)) {
         Redirect(routes.DeclarationForIsaManagersController.onPageLoad())
       } else {
         Redirect(TaskListController.onPageLoad())

--- a/app/controllers/TaskListController.scala
+++ b/app/controllers/TaskListController.scala
@@ -31,6 +31,7 @@ class TaskListController @Inject() (
   identify: IdentifierAction,
   getData: DataRetrievalAction,
   getUprn: EnrichRegisteredAddressUprnAction,
+  requireData: DataRequiredAction,
   val controllerComponents: MessagesControllerComponents,
   view: TaskListView
 ) extends FrontendBaseController
@@ -38,9 +39,9 @@ class TaskListController @Inject() (
     with Logging {
 
   def onPageLoad(): Action[AnyContent] =
-    (identify andThen getData andThen getUprn) { implicit request =>
+    (identify andThen getData andThen getUprn andThen requireData) { implicit request =>
       request.journeyData match {
-        case Some(journeyData) if TaskListViewModel.canAccessTaskList(journeyData) =>
+        case journeyData if TaskListViewModel.canAccessTaskList(journeyData) =>
           Ok(view(TaskListViewModel(journeyData, request.credentialRole)))
 
         case _ =>

--- a/app/controllers/TaskListController.scala
+++ b/app/controllers/TaskListController.scala
@@ -21,6 +21,7 @@ import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewmodels.tasklist.TaskListViewModel
 import views.html.TaskListView
 
 import javax.inject.Inject
@@ -38,6 +39,12 @@ class TaskListController @Inject() (
 
   def onPageLoad(): Action[AnyContent] =
     (identify andThen getData andThen getUprn) { implicit request =>
-      Ok(view())
+      request.journeyData match {
+        case Some(journeyData) if TaskListViewModel.canAccessTaskList(journeyData) =>
+          Ok(view(TaskListViewModel(journeyData, request.credentialRole)))
+
+        case _ =>
+          Redirect(routes.StartController.onPageLoad())
+      }
     }
 }

--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -30,7 +30,7 @@ class DataRequiredActionImpl @Inject() (implicit val executionContext: Execution
   override protected def refine[A](request: OptionalDataRequest[A]): Future[Either[Result, DataRequest[A]]] =
     request.journeyData match {
       case None       =>
-        Future.successful(Left(Redirect(routes.JourneyRecoveryController.onPageLoad())))
+        Future.successful(Left(Redirect(routes.StartController.onPageLoad())))
       case Some(data) =>
         Future.successful(
           Right(DataRequest(request.request, request.groupId, request.credentials, request.credentialRole, data))

--- a/app/controllers/isaproducts/IsaProductsController.scala
+++ b/app/controllers/isaproducts/IsaProductsController.scala
@@ -41,8 +41,7 @@ class IsaProductsController @Inject() (
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
-  // TODO Replace getOrCreateAction with DataRetrievalAction when ATs begin from /start page DFI-1709
-  getOrCreateJourneyDataAction: GetOrCreateJourneyDataAction,
+  requireData: DataRequiredAction,
   auditContinuation: AuditContinuationAction,
   formProvider: IsaProductsFormProvider,
   journeyAnswersService: JourneyAnswersService,
@@ -57,7 +56,7 @@ class IsaProductsController @Inject() (
   val form: Form[Set[IsaProduct]] = formProvider()
 
   def onPageLoad(mode: Mode, returnTo: Option[ReturnTo]): Action[AnyContent] =
-    (identify andThen getOrCreateJourneyDataAction andThen auditContinuation(IsaProducts.sectionName)) {
+    (identify andThen getData andThen requireData andThen auditContinuation(IsaProducts.sectionName)) {
       implicit request =>
         val preparedForm = (for {
           products <- request.journeyData.isaProducts

--- a/app/controllers/thirdparty/AddedThirdPartiesController.scala
+++ b/app/controllers/thirdparty/AddedThirdPartiesController.scala
@@ -80,7 +80,14 @@ class AddedThirdPartiesController @Inject() (
 
         if (count == appConfig.maxThirdParties) {
           Redirect(
-            navigator.nextPageFromAddedThirdParties(YesNoAnswer.No, count, connectedOrganisations, mode, returnTo)
+            navigator.nextPageFromAddedThirdParties(
+              YesNoAnswer.No,
+              count,
+              connectedOrganisations,
+              mode,
+              returnTo,
+              hasInProgressItems = inProgress.nonEmpty
+            )
           )
         } else {
           form
@@ -96,7 +103,16 @@ class AddedThirdPartiesController @Inject() (
                   )
                 ),
               answer =>
-                Redirect(navigator.nextPageFromAddedThirdParties(answer, count, connectedOrganisations, mode, returnTo))
+                Redirect(
+                  navigator.nextPageFromAddedThirdParties(
+                    answer,
+                    count,
+                    connectedOrganisations,
+                    mode,
+                    returnTo,
+                    hasInProgressItems = inProgress.nonEmpty
+                  )
+                )
             )
         }
       }

--- a/app/models/journeydata/thirdparty/ThirdParty.scala
+++ b/app/models/journeydata/thirdparty/ThirdParty.scala
@@ -27,8 +27,15 @@ case class ThirdParty(
   usingInvestorFunds: Option[YesNoAnswer] = None,
   investorFundsPercentage: Option[String] = None
 ) {
-  def inProgress: Boolean =
-    List(thirdPartyName, managingIsaReturns, usingInvestorFunds).exists(_.iterator.isEmpty)
+  def inProgress: Boolean = {
+    val missingRequiredAnswers =
+      List(thirdPartyName, managingIsaReturns, usingInvestorFunds).exists(_.iterator.isEmpty)
+
+    val missingInvestorFundsPercentage =
+      usingInvestorFunds.contains(YesNoAnswer.Yes) && investorFundsPercentage.isEmpty
+
+    missingRequiredAnswers || missingInvestorFundsPercentage
+  }
 }
 
 object ThirdParty {

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -101,9 +101,10 @@ class Navigator @Inject() () {
     count: Int,
     connectedOrganisations: Seq[String] = Nil,
     mode: Mode,
-    returnTo: Option[ReturnTo]
+    returnTo: Option[ReturnTo],
+    hasInProgressItems: Boolean = false
   ): Call =
-    addedThirdPartiesNextPage(answer, count, connectedOrganisations, mode, returnTo)
+    addedThirdPartiesNextPage(answer, count, connectedOrganisations, mode, returnTo, hasInProgressItems)
 
   // TODO: Consider creating navigator defs for each task list journey to keep maintainable and clear
   private[navigation] def normalRoutes[A <: TaskListSection](
@@ -285,9 +286,12 @@ class Navigator @Inject() () {
     count: Int,
     connectedOrganisations: Seq[String],
     mode: Mode,
-    returnTo: Option[ReturnTo]
+    returnTo: Option[ReturnTo],
+    hasInProgressItems: Boolean
   ): Call =
     (answer, returnTo) match {
+      case (YesNoAnswer.No, _) if hasInProgressItems                          =>
+        TaskListController.onPageLoad()
       case (YesNoAnswer.No, _) if count > 1 && connectedOrganisations.isEmpty =>
         ThirdPartyConnectedOrganisationsController.onPageLoad(NormalMode, returnTo)
       case (YesNoAnswer.No, Some(SubmissionCyaViaAddedThirdParties))          =>

--- a/app/viewmodels/tasklist/TaskListViewModel.scala
+++ b/app/viewmodels/tasklist/TaskListViewModel.scala
@@ -82,9 +82,8 @@ object TaskListViewModel {
   def apply(journeyData: JourneyData, credentialRole: CredentialRole)(implicit
     messages: Messages
   ): TaskListViewModel = {
-    val organisationInformationCompleted = isOrganisationInformationComplete(journeyData)
-    val remainingTasksUnlocked           = organisationInformationCompleted
-    val submitAnswersAvailable           = canSubmitAnswers(journeyData, credentialRole)
+    val remainingTasksUnlocked = canAccessTaskList(journeyData)
+    val submitAnswersAvailable = canSubmitAnswers(journeyData, credentialRole)
 
     TaskListViewModel(
       sections = Seq(

--- a/app/viewmodels/tasklist/TaskListViewModel.scala
+++ b/app/viewmodels/tasklist/TaskListViewModel.scala
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.tasklist
+
+import controllers.certificatesofauthority.routes.{CoaCheckYourAnswersController, EligibilityToManageIsaController}
+import controllers.isaproducts.routes.{IsaProductsCheckYourAnswersController, IsaProductsController}
+import controllers.liaisonofficers.routes.{AddedLiaisonOfficersController, LiaisonOfficerNameController}
+import controllers.orgdetails.routes.{OrganisationDetailsCheckYourAnswersController, RegisteredIsaManagerController}
+import controllers.orgemail.routes.{EmailVerificationCodeController, OrganisationEmailAddressController, OrganisationEmailCyaController}
+import controllers.signatories.routes.{AddedSignatoryController, SignatoryNameController}
+import controllers.thirdparty.routes.{AddedThirdPartiesController, ProductsManagedByThirdPartyController, ThirdPartiesCheckYourAnswersController}
+import controllers.routes.SubmissionCyaController
+import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.{No as CertificatesNo, Yes as CertificatesYes}
+import models.journeydata.isaproducts.InnovativeFinancialProduct.PeertopeerLoansUsingAPlatformWith36hPermissions
+import models.journeydata.isaproducts.IsaProduct.InnovativeFinanceIsas
+import models.journeydata.JourneyData
+import models.{CheckMode, NormalMode, YesNoAnswer}
+import play.api.i18n.Messages
+import uk.gov.hmrc.auth.core.{CredentialRole, User}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Empty, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.tag.Tag
+import uk.gov.hmrc.govukfrontend.views.viewmodels.tasklist.{TaskList, TaskListItem, TaskListItemStatus, TaskListItemTitle}
+
+case class TaskListStatus(content: String, tagClass: Option[String] = None) {
+  def toGovuk: TaskListItemStatus =
+    if (this == TaskListStatus.NoStatus) {
+      TaskListItemStatus()
+    } else {
+      TaskListItemStatus(
+        tag = tagClass.map(cssClass => Tag(content = Text(content), classes = cssClass)),
+        content = if (tagClass.isDefined) Empty else Text(content)
+      )
+    }
+}
+
+object TaskListStatus {
+  val NoStatus: TaskListStatus = TaskListStatus("")
+}
+
+case class TaskListTaskViewModel(
+  title: String,
+  href: Option[String],
+  status: TaskListStatus
+) {
+  def toGovuk: TaskListItem =
+    TaskListItem(
+      title = TaskListItemTitle(content = Text(title)),
+      href = href,
+      status = status.toGovuk
+    )
+}
+
+case class TaskListSectionViewModel(
+  heading: String,
+  tasks: Seq[TaskListTaskViewModel]
+) {
+  def toGovuk: TaskList =
+    TaskList(items = tasks.map(_.toGovuk))
+}
+
+case class TaskListViewModel(
+  sections: Seq[TaskListSectionViewModel],
+  canSubmitAnswers: Boolean
+)
+
+object TaskListViewModel {
+
+  def apply(journeyData: JourneyData, credentialRole: CredentialRole)(implicit
+    messages: Messages
+  ): TaskListViewModel = {
+    val organisationInformationCompleted = isOrganisationInformationComplete(journeyData)
+    val remainingTasksUnlocked           = organisationInformationCompleted
+    val submitAnswersAvailable           = canSubmitAnswers(journeyData, credentialRole)
+
+    TaskListViewModel(
+      sections = Seq(
+        TaskListSectionViewModel(
+          messages("taskList.section.organisationInformation"),
+          Seq(
+            organisationInformationTask(journeyData),
+            organisationEmailTask(journeyData, remainingTasksUnlocked)
+          )
+        ),
+        TaskListSectionViewModel(
+          messages("taskList.section.eligibility"),
+          Seq(
+            isaProductsTask(journeyData, remainingTasksUnlocked),
+            certificatesOfAuthorityTask(journeyData, remainingTasksUnlocked)
+          )
+        ),
+        TaskListSectionViewModel(
+          messages("taskList.section.authorisedUsers"),
+          Seq(
+            liaisonOfficersTask(journeyData, remainingTasksUnlocked),
+            signatoriesTask(journeyData, remainingTasksUnlocked)
+          )
+        ),
+        TaskListSectionViewModel(
+          messages("taskList.section.thirdPartyOrganisations"),
+          Seq(thirdPartyOrganisationsTask(journeyData, remainingTasksUnlocked))
+        ),
+        TaskListSectionViewModel(
+          messages("taskList.section.submit"),
+          Seq(submitAnswersTask(submitAnswersAvailable, credentialRole))
+        )
+      ),
+      canSubmitAnswers = submitAnswersAvailable
+    )
+  }
+
+  def canAccessTaskList(journeyData: JourneyData): Boolean =
+    journeyData.businessVerification.exists { businessVerification =>
+      businessVerification.businessRegistrationPassed.contains(true) &&
+      businessVerification.businessVerificationPassed.contains(true)
+    }
+
+  def canSubmitAnswers(journeyData: JourneyData, credentialRole: CredentialRole): Boolean =
+    credentialRole == User && canAccessTaskList(journeyData) && allRequiredTasksComplete(journeyData)
+
+  def allRequiredTasksComplete(journeyData: JourneyData): Boolean =
+    isOrganisationInformationComplete(journeyData) &&
+      isOrganisationEmailVerified(journeyData) &&
+      isIsaProductsComplete(journeyData) &&
+      isCertificatesOfAuthorityComplete(journeyData) &&
+      areLiaisonOfficersComplete(journeyData) &&
+      areSignatoriesComplete(journeyData) &&
+      areThirdPartyOrganisationsComplete(journeyData)
+
+  private def organisationInformationTask(journeyData: JourneyData)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val completed = isOrganisationInformationComplete(journeyData)
+    val started   = organisationInformationStarted(journeyData)
+
+    TaskListTaskViewModel(
+      title =
+        if (completed) messages("taskList.organisationInformation.change")
+        else messages("taskList.organisationInformation.add"),
+      href = Some(
+        if (completed) OrganisationDetailsCheckYourAnswersController.onPageLoad().url
+        else RegisteredIsaManagerController.onPageLoad(NormalMode).url
+      ),
+      status =
+        if (completed) plain("taskList.status.completed")
+        else if (started) blueTag("taskList.status.inProgress")
+        else blueTag("taskList.status.notYetStarted")
+    )
+  }
+
+  private def organisationEmailTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val email    = journeyData.organisationEmail.flatMap(_.organisationEmail)
+    val verified = isOrganisationEmailVerified(journeyData)
+
+    TaskListTaskViewModel(
+      title =
+        if (verified) messages("taskList.organisationEmail.change")
+        else messages("taskList.organisationEmail.add"),
+      href = hrefWhen(
+        unlocked,
+        if (verified) OrganisationEmailCyaController.onPageLoad().url
+        else if (email.isDefined) EmailVerificationCodeController.onPageLoad(NormalMode).url
+        else OrganisationEmailAddressController.onPageLoad(NormalMode).url
+      ),
+      status =
+        if (!unlocked) plain("taskList.status.cannotStartYet")
+        else if (verified) plain("taskList.status.verified")
+        else if (email.isDefined) yellowTag("taskList.status.notVerified")
+        else blueTag("taskList.status.notYetStarted")
+    )
+  }
+
+  private def isaProductsTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel =
+    standardTask(
+      unlocked = unlocked,
+      complete = isIsaProductsComplete(journeyData),
+      started = isaProductsStarted(journeyData),
+      addMessage = "taskList.isaProducts.add",
+      changeMessage = "taskList.isaProducts.change",
+      addHref = IsaProductsController.onPageLoad(NormalMode).url,
+      changeHref = IsaProductsCheckYourAnswersController.onPageLoad().url
+    )
+
+  private def certificatesOfAuthorityTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel =
+    standardTask(
+      unlocked = unlocked,
+      complete = isCertificatesOfAuthorityComplete(journeyData),
+      started = certificatesOfAuthorityStarted(journeyData),
+      addMessage = "taskList.certificatesOfAuthority.add",
+      changeMessage = "taskList.certificatesOfAuthority.change",
+      addHref = EligibilityToManageIsaController.onPageLoad().url,
+      changeHref = CoaCheckYourAnswersController.onPageLoad().url
+    )
+
+  private def liaisonOfficersTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val liaisonOfficers = journeyData.liaisonOfficers.fold(Seq.empty)(_.liaisonOfficers)
+
+    countedTask(
+      unlocked = unlocked,
+      count = liaisonOfficers.size,
+      hasIncompleteItems = liaisonOfficers.exists(_.inProgress),
+      addMessage = "taskList.liaisonOfficers.add",
+      changeMessage = "taskList.liaisonOfficers.change",
+      addHref = LiaisonOfficerNameController.onPageLoad(id = None, mode = NormalMode, returnTo = None).url,
+      changeHref = AddedLiaisonOfficersController.onPageLoad(NormalMode).url,
+      singularMessage = "taskList.count.liaisonOfficer.one",
+      pluralMessage = "taskList.count.liaisonOfficer.other"
+    )
+  }
+
+  private def signatoriesTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val signatories = journeyData.signatories.fold(Seq.empty)(_.signatories)
+
+    countedTask(
+      unlocked = unlocked,
+      count = signatories.size,
+      hasIncompleteItems = signatories.exists(_.inProgress),
+      addMessage = "taskList.signatories.add",
+      changeMessage = "taskList.signatories.change",
+      addHref = SignatoryNameController.onPageLoad(id = None, mode = NormalMode, returnTo = None).url,
+      changeHref = AddedSignatoryController.onPageLoad(NormalMode).url,
+      singularMessage = "taskList.count.signatory.one",
+      pluralMessage = "taskList.count.signatory.other"
+    )
+  }
+
+  private def thirdPartyOrganisationsTask(journeyData: JourneyData, unlocked: Boolean)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val section            = journeyData.thirdPartyOrganisations
+    val count              = section.fold(0)(_.thirdParties.size)
+    val complete           = areThirdPartyOrganisationsComplete(journeyData)
+    val started            = section.flatMap(_.managedByThirdParty).isDefined
+    val hasIncompleteItems =
+      section.exists(_.thirdParties.exists(_.inProgress))
+
+    TaskListTaskViewModel(
+      title =
+        if (complete || count > 0) messages("taskList.thirdPartyOrganisations.change")
+        else messages("taskList.thirdPartyOrganisations.add"),
+      href = hrefWhen(
+        unlocked,
+        if (hasIncompleteItems) AddedThirdPartiesController.onPageLoad(NormalMode).url
+        else if (count > 1) ThirdPartiesCheckYourAnswersController.onPageLoad().url
+        else if (count > 0) AddedThirdPartiesController.onPageLoad(NormalMode).url
+        else if (complete) ProductsManagedByThirdPartyController.onPageLoad(CheckMode).url
+        else ProductsManagedByThirdPartyController.onPageLoad(NormalMode).url
+      ),
+      status =
+        if (!unlocked) plain("taskList.status.cannotStartYet")
+        else if (complete && count == 0) plain("taskList.status.completed")
+        else if (hasIncompleteItems) blueTag("taskList.status.inProgress")
+        else if (count > 0) countStatus(count, "taskList.count.thirdParty.one", "taskList.count.thirdParty.other")
+        else if (started) blueTag("taskList.status.inProgress")
+        else blueTag("taskList.status.notYetStarted")
+    )
+  }
+
+  private def submitAnswersTask(canSubmit: Boolean, credentialRole: CredentialRole)(implicit
+    messages: Messages
+  ): TaskListTaskViewModel = {
+    val isAdministrator = credentialRole == User
+
+    TaskListTaskViewModel(
+      title =
+        if (isAdministrator) messages("taskList.submit.checkAnswers")
+        else messages("taskList.submit.assistantCannotSubmit"),
+      href = hrefWhen(canSubmit, SubmissionCyaController.onPageLoad().url),
+      status =
+        if (!isAdministrator) TaskListStatus.NoStatus
+        else if (canSubmit) blueTag("taskList.status.notYetStarted")
+        else plain("taskList.status.cannotStartYet")
+    )
+  }
+
+  private def standardTask(
+    unlocked: Boolean,
+    complete: Boolean,
+    started: Boolean,
+    addMessage: String,
+    changeMessage: String,
+    addHref: String,
+    changeHref: String
+  )(implicit messages: Messages): TaskListTaskViewModel =
+    TaskListTaskViewModel(
+      title = if (complete) messages(changeMessage) else messages(addMessage),
+      href = hrefWhen(unlocked, if (complete) changeHref else addHref),
+      status =
+        if (!unlocked) plain("taskList.status.cannotStartYet")
+        else if (complete) plain("taskList.status.completed")
+        else if (started) blueTag("taskList.status.inProgress")
+        else blueTag("taskList.status.notYetStarted")
+    )
+
+  private def countedTask(
+    unlocked: Boolean,
+    count: Int,
+    hasIncompleteItems: Boolean,
+    addMessage: String,
+    changeMessage: String,
+    addHref: String,
+    changeHref: String,
+    singularMessage: String,
+    pluralMessage: String
+  )(implicit messages: Messages): TaskListTaskViewModel =
+    TaskListTaskViewModel(
+      title = if (count > 0) messages(changeMessage) else messages(addMessage),
+      href = hrefWhen(unlocked, if (count > 0) changeHref else addHref),
+      status =
+        if (!unlocked) plain("taskList.status.cannotStartYet")
+        else if (hasIncompleteItems) blueTag("taskList.status.inProgress")
+        else if (count > 0) countStatus(count, singularMessage, pluralMessage)
+        else blueTag("taskList.status.notYetStarted")
+    )
+
+  private def hrefWhen(enabled: Boolean, href: String): Option[String] =
+    Option.when(enabled)(href)
+
+  private def plain(message: String)(implicit messages: Messages): TaskListStatus =
+    TaskListStatus(messages(message))
+
+  private def blueTag(message: String)(implicit messages: Messages): TaskListStatus =
+    TaskListStatus(messages(message), Some("govuk-tag--blue"))
+
+  private def yellowTag(message: String)(implicit messages: Messages): TaskListStatus =
+    TaskListStatus(messages(message), Some("govuk-tag--yellow"))
+
+  private def countStatus(count: Int, singularMessage: String, pluralMessage: String)(implicit
+    messages: Messages
+  ): TaskListStatus =
+    TaskListStatus(messages(if (count == 1) singularMessage else pluralMessage, count))
+
+  private def isOrganisationInformationComplete(journeyData: JourneyData): Boolean =
+    journeyData.organisationDetails.exists { organisationDetails =>
+      organisationDetails.registeredToManageIsa.exists { registeredToManageIsa =>
+        val zReferenceComplete =
+          registeredToManageIsa == YesNoAnswer.No || organisationDetails.zRefNumber.exists(nonEmpty)
+
+        val tradingNameComplete =
+          organisationDetails.tradingUsingDifferentName.exists {
+            case YesNoAnswer.Yes => organisationDetails.tradingName.exists(nonEmpty)
+            case YesNoAnswer.No  => true
+          }
+
+        val correspondenceAddressComplete =
+          organisationDetails.registeredAddressCorrespondence.exists {
+            case YesNoAnswer.Yes => true
+            case YesNoAnswer.No  => organisationDetails.correspondenceAddress.exists(_.isPopulated)
+          }
+
+        zReferenceComplete &&
+        tradingNameComplete &&
+        organisationDetails.fcaNumber.exists(nonEmpty) &&
+        correspondenceAddressComplete &&
+        organisationDetails.orgTelephoneNumber.exists(nonEmpty)
+      }
+    }
+
+  private def organisationInformationStarted(journeyData: JourneyData): Boolean =
+    journeyData.organisationDetails.exists { organisationDetails =>
+      Seq(
+        organisationDetails.registeredToManageIsa,
+        organisationDetails.zRefNumber,
+        organisationDetails.tradingUsingDifferentName,
+        organisationDetails.tradingName,
+        organisationDetails.fcaNumber,
+        organisationDetails.registeredAddressCorrespondence,
+        organisationDetails.correspondenceAddress,
+        organisationDetails.orgTelephoneNumber,
+        organisationDetails.addAnotherAddress
+      ).exists(_.isDefined)
+    }
+
+  private def isOrganisationEmailVerified(journeyData: JourneyData): Boolean =
+    journeyData.organisationEmail.exists { organisationEmail =>
+      organisationEmail.organisationEmail.exists(nonEmpty) && organisationEmail.verified.contains(true)
+    }
+
+  private def isIsaProductsComplete(journeyData: JourneyData): Boolean =
+    journeyData.isaProducts.exists { isaProducts =>
+      isaProducts.isaProducts.exists(_.nonEmpty) &&
+      (!isaProducts.isaProducts.exists(_.contains(InnovativeFinanceIsas)) ||
+        (
+          isaProducts.innovativeFinancialProducts.exists(_.nonEmpty) &&
+            (!isaProducts.innovativeFinancialProducts.exists(
+              _.contains(PeertopeerLoansUsingAPlatformWith36hPermissions)
+            ) ||
+              (isaProducts.p2pPlatform.exists(nonEmpty) && isaProducts.p2pPlatformNumber.exists(nonEmpty)))
+        ))
+    }
+
+  private def isaProductsStarted(journeyData: JourneyData): Boolean =
+    journeyData.isaProducts.exists { isaProducts =>
+      Seq(
+        isaProducts.isaProducts,
+        isaProducts.innovativeFinancialProducts,
+        isaProducts.p2pPlatform,
+        isaProducts.p2pPlatformNumber
+      ).exists(_.isDefined)
+    }
+
+  private def isCertificatesOfAuthorityComplete(journeyData: JourneyData): Boolean =
+    journeyData.certificatesOfAuthority.exists { certificatesOfAuthority =>
+      certificatesOfAuthority.certificatesYesNo.exists {
+        case CertificatesYes => certificatesOfAuthority.fcaArticles.exists(_.nonEmpty)
+        case CertificatesNo  => certificatesOfAuthority.financialOrganisation.exists(_.nonEmpty)
+      }
+    }
+
+  private def certificatesOfAuthorityStarted(journeyData: JourneyData): Boolean =
+    journeyData.certificatesOfAuthority.exists { certificatesOfAuthority =>
+      Seq(
+        certificatesOfAuthority.certificatesYesNo,
+        certificatesOfAuthority.fcaArticles,
+        certificatesOfAuthority.financialOrganisation
+      ).exists(_.isDefined)
+    }
+
+  private def areLiaisonOfficersComplete(journeyData: JourneyData): Boolean =
+    journeyData.liaisonOfficers.exists { liaisonOfficers =>
+      liaisonOfficers.liaisonOfficers.nonEmpty && liaisonOfficers.liaisonOfficers.forall(!_.inProgress)
+    }
+
+  private def areSignatoriesComplete(journeyData: JourneyData): Boolean =
+    journeyData.signatories.exists { signatories =>
+      signatories.signatories.nonEmpty && signatories.signatories.forall(!_.inProgress)
+    }
+
+  private def areThirdPartyOrganisationsComplete(journeyData: JourneyData): Boolean =
+    journeyData.thirdPartyOrganisations.exists { thirdPartyOrganisations =>
+      thirdPartyOrganisations.managedByThirdParty.exists {
+        case YesNoAnswer.No  => true
+        case YesNoAnswer.Yes =>
+          thirdPartyOrganisations.thirdParties.nonEmpty && thirdPartyOrganisations.thirdParties.forall(!_.inProgress)
+      }
+    }
+
+  private def nonEmpty(value: String): Boolean =
+    value.trim.nonEmpty
+}

--- a/app/views/TaskListView.scala.html
+++ b/app/views/TaskListView.scala.html
@@ -14,28 +14,27 @@
  * limitations under the License.
  *@
 
-@import models.NormalMode
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcPageHeading
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukTaskList
+@import viewmodels.tasklist.TaskListViewModel
 
 @this(
   layout: templates.Layout,
-  hmrcPageHeading: HmrcPageHeading
+  hmrcPageHeading: HmrcPageHeading,
+  govukTaskList: GovukTaskList
 )
 
-@()(implicit request: Request[_], messages: Messages)
+@(viewModel: TaskListViewModel)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("taskList.title"))) {
+@layout(pageTitle = titleNoForm(messages("taskList.title")), showBackLink = false) {
 
-    <div class="govuk-body">
-        @hmrcPageHeading(PageHeading(
-            text = messages("taskList.heading"),
-            headingClasses = Some("govuk-heading-l")
-        ))
-        <a class="govuk-link govuk-body" href="@controllers.isaproducts.routes.IsaProductsController.onPageLoad(NormalMode).url">
-            ISA Products</a>
-        <br>
-        <a class="govuk-link govuk-body" href="@controllers.signatories.routes.SignatoryNameController.onPageLoad(id = None, mode = NormalMode).url">
-            Signatories</a>
+    @hmrcPageHeading(PageHeading(
+        text = messages("taskList.heading"),
+        headingClasses = Some("govuk-heading-l")
+    ))
 
-    </div>
+    @for(section <- viewModel.sections) {
+        <h2 class="govuk-heading-m">@section.heading</h2>
+        @govukTaskList(section.toGovuk)
+    }
 }

--- a/app/views/certificatesofauthority/CoaCheckYourAnswersView.scala.html
+++ b/app/views/certificatesofauthority/CoaCheckYourAnswersView.scala.html
@@ -34,7 +34,7 @@
         headingClasses = Some("govuk-heading-l"),
     ))
 
-    @formHelper(action = routes.IndexController.onPageLoad(), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.TaskListController.onPageLoad(), Symbol("autoComplete") -> "off") {
 
         @govukSummaryList(list)
         @govukButton(

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -66,6 +66,6 @@
     backLink = if (showBackLink) Some(BackLink.mimicsBrowserBackButtonViaJavaScript) else None,
     serviceNavigation = Some(ServiceNavigation(
         serviceName = Some(messages("service.name")),
-        serviceUrl = Some(routes.IndexController.onPageLoad().url)
+        serviceUrl = Some(routes.TaskListController.onPageLoad().url)
       ))
 ))(content)

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
+@import views.html.helper.CSPNonce
 
 @this(
     appConfig: FrontendAppConfig,
@@ -43,6 +44,10 @@
     }
 }
 
+@additionalScripts= {
+    <script @CSPNonce.attr src='@routes.Assets.versioned("javascript/print-link.js")'></script>
+}
+
 @content = {
     @contentBlock
     <p>
@@ -53,7 +58,8 @@
 @hmrcStandardPage(HmrcStandardPageParams(
     pageTitle = Some(pageTitle),
     templateOverrides = TemplateOverrides(
-        additionalHeadBlock = Some(head)
+        additionalHeadBlock = Some(head),
+        additionalScriptsBlock = Some(additionalScripts)
     ),
     serviceURLs = ServiceURLs(
         signOutUrl = if(showSignOut) Some(controllers.auth.routes.AuthController.signOut().url) else None

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -551,8 +551,41 @@ CoaCheckYourAnswers.heading = Check your certificates of authority
 
 
 ### Task List
-taskList.title = Task List
-taskList.heading = Task List
+taskList.title = Manage ISAs
+taskList.heading = Manage ISAs
+taskList.section.organisationInformation = Organisation information
+taskList.section.eligibility = Eligibility
+taskList.section.authorisedUsers = Authorised users
+taskList.section.thirdPartyOrganisations = Third party organisations
+taskList.section.submit = Submit answers
+taskList.organisationInformation.add = Add organisation information
+taskList.organisationInformation.change = Change organisation information
+taskList.organisationEmail.add = Add organisation email
+taskList.organisationEmail.change = Change organisation email
+taskList.isaProducts.add = ISA products you manage
+taskList.isaProducts.change = Change ISA products you manage
+taskList.certificatesOfAuthority.add = Which certificates of authority apply to your organisation
+taskList.certificatesOfAuthority.change = Change which certificates of authority apply to your organisation
+taskList.liaisonOfficers.add = Add liaison officers
+taskList.liaisonOfficers.change = Change liaison officers
+taskList.signatories.add = Add signatories
+taskList.signatories.change = Change signatories
+taskList.thirdPartyOrganisations.add = Add organisations you outsource to
+taskList.thirdPartyOrganisations.change = Change organisations you outsource to
+taskList.submit.checkAnswers = Check answers and submit
+taskList.submit.assistantCannotSubmit = Only Administrators can submit the final answers
+taskList.status.notYetStarted = Not yet started
+taskList.status.inProgress = In progress
+taskList.status.completed = Completed
+taskList.status.cannotStartYet = Cannot start yet
+taskList.status.verified = Verified
+taskList.status.notVerified = Not verified
+taskList.count.liaisonOfficer.one = {0} liaison officer
+taskList.count.liaisonOfficer.other = {0} liaison officers
+taskList.count.signatory.one = {0} signatory
+taskList.count.signatory.other = {0} signatories
+taskList.count.thirdParty.one = {0} third party
+taskList.count.thirdParty.other = {0} third parties
 
 
 ### Business Verification Lockout

--- a/it/test/controllers/IsaProductsControllerISpec.scala
+++ b/it/test/controllers/IsaProductsControllerISpec.scala
@@ -31,29 +31,23 @@ class IsaProductsControllerISpec extends BaseIntegrationSpec with CommonStubs wi
   private val controllerEndpoint = "/obligations/enrolment/isa/isa-products"
   private val getJourneyDataUrl = s"/disa-registration/store/$testGroupId"
   private val updateJourneyUrl = s"/disa-registration/store/$testGroupId/isaProducts"
-  private val getOrCreateEnrolmentUrl = s"/disa-registration/journey/$testGroupId"
 
   "GET /isa-products" should {
 
     "fetch data from the correct endpoint" in {
-      val getOrCreateResponse =
+      val journeyDataResponse =
         s"""
           |{
-          |  "isNewEnrolmentJourney": true,
-          |  "journeyData": {
           |    "groupId": "$testGroupId",
           |    "enrolmentId": "$testString",
           |     "isaProducts": {
           |       "isaProducts": ["cashJuniorIsas", "cashIsas", "stocksAndSharesIsas", "stocksAndSharesJuniorIsas", "innovativeFinanceIsas"]
           |     }
-          |  }
           |}
           |""" .stripMargin
 
       stubAuth()
-      stubPut(getOrCreateEnrolmentUrl, OK, getOrCreateResponse)
-      // TODO Replace PUT call with below line when ATs begin from /start page DFI-1709
-      //stubGet(getJourneyDataUrl, OK, testJourneyData)
+      stubGet(getJourneyDataUrl, OK, journeyDataResponse)
 
       val request =
         FakeRequest(GET, controllerEndpoint)

--- a/test/controllers/SubmissionCyaControllerSpec.scala
+++ b/test/controllers/SubmissionCyaControllerSpec.scala
@@ -17,18 +17,6 @@
 package controllers
 
 import base.SpecBase
-import models.YesNoAnswer
-import models.journeydata.OrganisationDetails
-import models.journeydata.certificatesofauthority.CertificatesOfAuthority
-import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.Yes as CertificatesYes
-import models.journeydata.certificatesofauthority.FcaArticles.Article14
-import models.journeydata.isaproducts.IsaProduct.CashIsas
-import models.journeydata.isaproducts.IsaProducts
-import models.journeydata.liaisonofficers.LiaisonOfficerCommunication.ByEmail
-import models.journeydata.liaisonofficers.{LiaisonOfficer, LiaisonOfficers}
-import models.journeydata.signatories.{Signatories, Signatory}
-import models.journeydata.thirdparty.ThirdPartyOrganisations
-import models.journeydata.{JourneyData, OrganisationEmail}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.Assistant
@@ -40,7 +28,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
   "Submission CYA Controller" - {
 
     "must return OK and the correct view for a GET when the user can submit" in {
-      val application = applicationBuilder(journeyData = Some(completeJourneyData)).build()
+      val application = applicationBuilder(journeyData = Some(completeTaskListJourneyData)).build()
 
       running(application) {
         val request = FakeRequest(GET, routes.SubmissionCyaController.onPageLoad().url)
@@ -48,7 +36,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         val view      = application.injector.instanceOf[SubmissionCyaView]
-        val viewModel = SubmissionCyaViewModel(completeJourneyData)(messages(application))
+        val viewModel = SubmissionCyaViewModel(completeTaskListJourneyData)(messages(application))
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
@@ -56,7 +44,8 @@ class SubmissionCyaControllerSpec extends SpecBase {
     }
 
     "must redirect to TaskList for a GET if user is assistant" in {
-      val application = applicationBuilder(journeyData = Some(completeJourneyData), credentialRole = Assistant).build()
+      val application =
+        applicationBuilder(journeyData = Some(completeTaskListJourneyData), credentialRole = Assistant).build()
 
       running(application) {
         val request = FakeRequest(GET, routes.SubmissionCyaController.onPageLoad().url)
@@ -95,7 +84,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
     }
 
     "must redirect to the declaration page for a POST when the user can submit" in {
-      val application = applicationBuilder(journeyData = Some(completeJourneyData)).build()
+      val application = applicationBuilder(journeyData = Some(completeTaskListJourneyData)).build()
 
       running(application) {
         val request = FakeRequest(POST, routes.SubmissionCyaController.onSubmit().url)
@@ -108,7 +97,8 @@ class SubmissionCyaControllerSpec extends SpecBase {
     }
 
     "must redirect back to task list for a POST when the user is assistant" in {
-      val application = applicationBuilder(journeyData = Some(completeJourneyData), credentialRole = Assistant).build()
+      val application =
+        applicationBuilder(journeyData = Some(completeTaskListJourneyData), credentialRole = Assistant).build()
 
       running(application) {
         val request = FakeRequest(POST, routes.SubmissionCyaController.onSubmit().url)
@@ -133,38 +123,4 @@ class SubmissionCyaControllerSpec extends SpecBase {
       }
     }
   }
-
-  private def completeJourneyData: JourneyData =
-    emptyJourneyData.copy(
-      businessVerification = Some(testBV),
-      organisationDetails = Some(
-        OrganisationDetails(
-          registeredToManageIsa = Some(YesNoAnswer.No),
-          tradingUsingDifferentName = Some(YesNoAnswer.No),
-          fcaNumber = Some("123456"),
-          registeredAddressCorrespondence = Some(YesNoAnswer.Yes),
-          orgTelephoneNumber = Some("01234567890")
-        )
-      ),
-      organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(true))),
-      isaProducts = Some(IsaProducts(isaProducts = Some(Seq(CashIsas)))),
-      certificatesOfAuthority = Some(
-        CertificatesOfAuthority(certificatesYesNo = Some(CertificatesYes), fcaArticles = Some(Seq(Article14)))
-      ),
-      liaisonOfficers = Some(
-        LiaisonOfficers(
-          Seq(
-            LiaisonOfficer(
-              id = "lo-1",
-              fullName = Some("Complete Liaison Officer"),
-              phoneNumber = Some("01234567890"),
-              communication = Set(ByEmail),
-              email = Some("liaison@example.com")
-            )
-          )
-        )
-      ),
-      signatories = Some(Signatories(Seq(Signatory("sig-1", Some("Complete Signatory"), Some("Director"))))),
-      thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
-    )
 }

--- a/test/controllers/SubmissionCyaControllerSpec.scala
+++ b/test/controllers/SubmissionCyaControllerSpec.scala
@@ -17,6 +17,18 @@
 package controllers
 
 import base.SpecBase
+import models.YesNoAnswer
+import models.journeydata.OrganisationDetails
+import models.journeydata.certificatesofauthority.CertificatesOfAuthority
+import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.Yes as CertificatesYes
+import models.journeydata.certificatesofauthority.FcaArticles.Article14
+import models.journeydata.isaproducts.IsaProduct.CashIsas
+import models.journeydata.isaproducts.IsaProducts
+import models.journeydata.liaisonofficers.LiaisonOfficerCommunication.ByEmail
+import models.journeydata.liaisonofficers.{LiaisonOfficer, LiaisonOfficers}
+import models.journeydata.signatories.{Signatories, Signatory}
+import models.journeydata.thirdparty.ThirdPartyOrganisations
+import models.journeydata.{JourneyData, OrganisationEmail}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.Assistant
@@ -28,7 +40,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
   "Submission CYA Controller" - {
 
     "must return OK and the correct view for a GET when the user can submit" in {
-      val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
+      val application = applicationBuilder(journeyData = Some(completeJourneyData)).build()
 
       running(application) {
         val request = FakeRequest(GET, routes.SubmissionCyaController.onPageLoad().url)
@@ -36,7 +48,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         val view      = application.injector.instanceOf[SubmissionCyaView]
-        val viewModel = SubmissionCyaViewModel(emptyJourneyData)(messages(application))
+        val viewModel = SubmissionCyaViewModel(completeJourneyData)(messages(application))
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(viewModel)(request, messages(application)).toString
@@ -44,7 +56,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
     }
 
     "must redirect to TaskList for a GET if user is assistant" in {
-      val application = applicationBuilder(journeyData = Some(emptyJourneyData), credentialRole = Assistant).build()
+      val application = applicationBuilder(journeyData = Some(completeJourneyData), credentialRole = Assistant).build()
 
       running(application) {
         val request = FakeRequest(GET, routes.SubmissionCyaController.onPageLoad().url)
@@ -56,7 +68,7 @@ class SubmissionCyaControllerSpec extends SpecBase {
       }
     }
 
-    "must redirect to JourneyRecoveryController for a GET if no existing data is found" in {
+    "must redirect to StartController for a GET if no existing data is found" in {
       val application = applicationBuilder(journeyData = None).build()
 
       running(application) {
@@ -65,12 +77,25 @@ class SubmissionCyaControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+        redirectLocation(result).value mustEqual routes.StartController.onPageLoad().url
+      }
+    }
+
+    "must redirect to TaskList for a GET if required tasks are incomplete" in {
+      val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.SubmissionCyaController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.TaskListController.onPageLoad().url
       }
     }
 
     "must redirect to the declaration page for a POST when the user can submit" in {
-      val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
+      val application = applicationBuilder(journeyData = Some(completeJourneyData)).build()
 
       running(application) {
         val request = FakeRequest(POST, routes.SubmissionCyaController.onSubmit().url)
@@ -83,7 +108,20 @@ class SubmissionCyaControllerSpec extends SpecBase {
     }
 
     "must redirect back to task list for a POST when the user is assistant" in {
-      val application = applicationBuilder(journeyData = Some(emptyJourneyData), credentialRole = Assistant).build()
+      val application = applicationBuilder(journeyData = Some(completeJourneyData), credentialRole = Assistant).build()
+
+      running(application) {
+        val request = FakeRequest(POST, routes.SubmissionCyaController.onSubmit().url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.TaskListController.onPageLoad().url
+      }
+    }
+
+    "must redirect back to task list for a POST when required tasks are incomplete" in {
+      val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
 
       running(application) {
         val request = FakeRequest(POST, routes.SubmissionCyaController.onSubmit().url)
@@ -95,4 +133,38 @@ class SubmissionCyaControllerSpec extends SpecBase {
       }
     }
   }
+
+  private def completeJourneyData: JourneyData =
+    emptyJourneyData.copy(
+      businessVerification = Some(testBV),
+      organisationDetails = Some(
+        OrganisationDetails(
+          registeredToManageIsa = Some(YesNoAnswer.No),
+          tradingUsingDifferentName = Some(YesNoAnswer.No),
+          fcaNumber = Some("123456"),
+          registeredAddressCorrespondence = Some(YesNoAnswer.Yes),
+          orgTelephoneNumber = Some("01234567890")
+        )
+      ),
+      organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(true))),
+      isaProducts = Some(IsaProducts(isaProducts = Some(Seq(CashIsas)))),
+      certificatesOfAuthority = Some(
+        CertificatesOfAuthority(certificatesYesNo = Some(CertificatesYes), fcaArticles = Some(Seq(Article14)))
+      ),
+      liaisonOfficers = Some(
+        LiaisonOfficers(
+          Seq(
+            LiaisonOfficer(
+              id = "lo-1",
+              fullName = Some("Complete Liaison Officer"),
+              phoneNumber = Some("01234567890"),
+              communication = Set(ByEmail),
+              email = Some("liaison@example.com")
+            )
+          )
+        )
+      ),
+      signatories = Some(Signatories(Seq(Signatory("sig-1", Some("Complete Signatory"), Some("Director"))))),
+      thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
+    )
 }

--- a/test/controllers/TaskListControllerSpec.scala
+++ b/test/controllers/TaskListControllerSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
+import viewmodels.tasklist.TaskListViewModel
 import views.html.TaskListView
 
 import scala.concurrent.Future
@@ -33,8 +34,9 @@ class TaskListControllerSpec extends SpecBase {
       when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
+      val journeyData = emptyJourneyData.copy(businessVerification = Some(testBV))
       val application = applicationBuilder(
-        journeyData = Some(emptyJourneyData)
+        journeyData = Some(journeyData)
       ).build()
 
       running(application) {
@@ -50,7 +52,10 @@ class TaskListControllerSpec extends SpecBase {
         status(result) mustEqual OK
 
         contentAsString(result) mustEqual
-          view()(request, messages(application)).toString
+          view(TaskListViewModel(journeyData, testCredentialRoleUser)(messages(application)))(
+            request,
+            messages(application)
+          ).toString
       }
     }
 
@@ -58,8 +63,9 @@ class TaskListControllerSpec extends SpecBase {
       when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
         .thenReturn(Future.failed(new RuntimeException("boom")))
 
+      val journeyData = emptyJourneyData.copy(businessVerification = Some(testBV))
       val application = applicationBuilder(
-        journeyData = Some(emptyJourneyData)
+        journeyData = Some(journeyData)
       ).build()
 
       running(application) {
@@ -71,6 +77,51 @@ class TaskListControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustEqual OK
+      }
+    }
+
+    "must redirect to Start when no journey data exists" in {
+      when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
+        .thenReturn(Future.successful(()))
+
+      val application = applicationBuilder(
+        journeyData = None
+      ).build()
+
+      running(application) {
+
+        val request =
+          FakeRequest(GET, routes.TaskListController.onPageLoad().url)
+            .withSession("authToken" -> "mock-bearer-token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.StartController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Start when business verification has not succeeded" in {
+      when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
+        .thenReturn(Future.successful(()))
+
+      val journeyData = emptyJourneyData.copy(
+        businessVerification = Some(testBV.copy(businessVerificationPassed = Some(false)))
+      )
+      val application = applicationBuilder(
+        journeyData = Some(journeyData)
+      ).build()
+
+      running(application) {
+
+        val request =
+          FakeRequest(GET, routes.TaskListController.onPageLoad().url)
+            .withSession("authToken" -> "mock-bearer-token")
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.StartController.onPageLoad().url
       }
     }
   }

--- a/test/controllers/TaskListControllerSpec.scala
+++ b/test/controllers/TaskListControllerSpec.scala
@@ -34,7 +34,7 @@ class TaskListControllerSpec extends SpecBase {
       when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
-      val journeyData = emptyJourneyData.copy(businessVerification = Some(testBV))
+      val journeyData = emptyJourneyDataWithBusinessVerification
       val application = applicationBuilder(
         journeyData = Some(journeyData)
       ).build()
@@ -63,7 +63,7 @@ class TaskListControllerSpec extends SpecBase {
       when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
         .thenReturn(Future.failed(new RuntimeException("boom")))
 
-      val journeyData = emptyJourneyData.copy(businessVerification = Some(testBV))
+      val journeyData = emptyJourneyDataWithBusinessVerification
       val application = applicationBuilder(
         journeyData = Some(journeyData)
       ).build()
@@ -105,9 +105,7 @@ class TaskListControllerSpec extends SpecBase {
       when(mockRegisteredAddressUprnService.enrichUprnIfMissing(any(), any(), any())(any()))
         .thenReturn(Future.successful(()))
 
-      val journeyData = emptyJourneyData.copy(
-        businessVerification = Some(testBV.copy(businessVerificationPassed = Some(false)))
-      )
+      val journeyData = emptyJourneyDataWithFailedBusinessVerification
       val application = applicationBuilder(
         journeyData = Some(journeyData)
       ).build()

--- a/test/controllers/isaproducts/IsaProductsControllerSpec.scala
+++ b/test/controllers/isaproducts/IsaProductsControllerSpec.scala
@@ -18,6 +18,7 @@ package controllers.isaproducts
 
 import base.SpecBase
 import controllers.isaproducts.routes.IsaProductsController
+import controllers.routes.StartController
 import forms.IsaProductsFormProvider
 import models.NormalMode
 import models.journeydata.JourneyData
@@ -51,22 +52,6 @@ class IsaProductsControllerSpec extends SpecBase with MockitoSugar {
     "must return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()
-
-      running(application) {
-        val request = FakeRequest(GET, isaProductsRoute)
-
-        val result = route(application, request).value
-
-        val view = application.injector.instanceOf[IsaProductsView]
-
-        status(result) mustEqual OK
-
-        contentAsString(result) mustEqual view(form, NormalMode, None)(request, messages(application)).toString
-      }
-    }
-
-    "must return OK and the correct view for a GET if no existing journey data found" in {
-      val application = applicationBuilder(journeyData = None).build()
 
       running(application) {
         val request = FakeRequest(GET, isaProductsRoute)
@@ -156,6 +141,19 @@ class IsaProductsControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must redirect to StartController if missing required data" in {
+      val application = applicationBuilder(journeyData = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, isaProductsRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual StartController.onPageLoad().url
       }
     }
 

--- a/test/controllers/orgdetails/OrganisationDetailsCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/orgdetails/OrganisationDetailsCheckYourAnswersControllerSpec.scala
@@ -47,7 +47,7 @@ class OrganisationDetailsCheckYourAnswersControllerSpec extends SpecBase {
       }
     }
 
-    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+    "must redirect to Start for a GET if no existing data is found" in {
 
       val application =
         applicationBuilder(journeyData = None).build()
@@ -62,7 +62,7 @@ class OrganisationDetailsCheckYourAnswersControllerSpec extends SpecBase {
         status(result) mustEqual SEE_OTHER
 
         redirectLocation(result).value mustEqual
-          controllers.routes.JourneyRecoveryController.onPageLoad().url
+          controllers.routes.StartController.onPageLoad().url
       }
     }
   }

--- a/test/controllers/thirdparty/AddedThirdPartiesControllerSpec.scala
+++ b/test/controllers/thirdparty/AddedThirdPartiesControllerSpec.scala
@@ -21,8 +21,6 @@ import config.FrontendAppConfig
 import controllers.routes.TaskListController
 import controllers.thirdparty.routes.*
 import models.ReturnTo.MultipleThirdPartiesCya
-import models.YesNoAnswer.Yes
-import models.journeydata.thirdparty.{ThirdParty, ThirdPartyOrganisations}
 import models.{NormalMode, YesNoAnswer}
 import org.mockito.Mockito.when
 import play.api.test.FakeRequest
@@ -35,29 +33,18 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
   private def routeUrl: String  = AddedThirdPartiesController.onPageLoad(NormalMode, None).url
   private def submitUrl: String = AddedThirdPartiesController.onSubmit(NormalMode).url
 
-  private val tp1 = ThirdParty("1", Some("Org 1"))
-  private val tp2 = ThirdParty("2", Some("Org 2"))
+  private val tp1 = inProgressTaskListThirdParty("1", "Org 1")
+  private val tp2 = inProgressTaskListThirdParty("2", "Org 2")
 
-  private val completeTp1 = completeThirdParty("1", "Org 1")
-  private val completeTp2 = completeThirdParty("2", "Org 2")
-
-  private def journeyData(thirdParties: Seq[ThirdParty]) =
-    testJourneyData.copy(
-      thirdPartyOrganisations = Some(
-        ThirdPartyOrganisations(
-          managedByThirdParty = Some(Yes),
-          thirdParties = thirdParties,
-          connectedOrganisations = Seq.empty
-        )
-      )
-    )
+  private val completeTp1 = completeTaskListThirdParty("1", "Org 1")
+  private val completeTp2 = completeTaskListThirdParty("2", "Org 2")
 
   "AddedThirdPartiesController" - {
 
     "must return OK on GET when third parties exist" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1, tp2)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1, tp2)))).build()
 
       val appConfig = application.injector.instanceOf[FrontendAppConfig]
 
@@ -90,7 +77,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
           .url
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1, tp2)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1, tp2)))).build()
 
       val appConfig = application.injector.instanceOf[FrontendAppConfig]
 
@@ -130,7 +117,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to task list when third parties empty" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq.empty))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq.empty))).build()
 
       running(application) {
         val result = route(application, FakeRequest(GET, routeUrl)).value
@@ -145,10 +132,10 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
 
       val maxList =
         (1 to mockAppConfig.maxThirdParties)
-          .map(i => completeThirdParty(i.toString, s"Org $i"))
+          .map(i => completeTaskListThirdParty(i.toString, s"Org $i"))
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(maxList))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(maxList))).build()
 
       running(application) {
         val request =
@@ -165,7 +152,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to ThirdPartiesCheckYourAnswerController when NO selected" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1)))).build()
 
       running(application) {
         val request =
@@ -182,7 +169,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must return BAD_REQUEST when invalid form and below max" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1)))).build()
 
       running(application) {
         val request = FakeRequest(POST, submitUrl)
@@ -196,7 +183,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to 'Connected Third Parties' page when NO selected and more than one third party exists" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(completeTp1, completeTp2)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(completeTp1, completeTp2)))).build()
 
       running(application) {
         val request =
@@ -213,7 +200,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to task list when NO selected and any third party is in progress" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(completeTp1, tp2)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(completeTp1, tp2)))).build()
 
       running(application) {
         val request =
@@ -230,7 +217,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to task list when NO selected and only one third party exists" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1)))).build()
 
       running(application) {
         val request =
@@ -247,7 +234,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to add page when YES selected and multiple but below max" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1, tp2)))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq(tp1, tp2)))).build()
 
       running(application) {
         val request =
@@ -265,7 +252,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to task list when section exists but no third parties after filtering" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq.empty))).build()
+        applicationBuilder(journeyData = Some(journeyDataWithThirdParties(Seq.empty))).build()
 
       running(application) {
         val request =
@@ -279,12 +266,4 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
       }
     }
   }
-
-  private def completeThirdParty(id: String, name: String): ThirdParty =
-    ThirdParty(
-      id = id,
-      thirdPartyName = Some(name),
-      managingIsaReturns = Some(YesNoAnswer.No),
-      usingInvestorFunds = Some(YesNoAnswer.No)
-    )
 }

--- a/test/controllers/thirdparty/AddedThirdPartiesControllerSpec.scala
+++ b/test/controllers/thirdparty/AddedThirdPartiesControllerSpec.scala
@@ -32,11 +32,14 @@ import views.html.thirdparty.AddedThirdPartiesView
 
 class AddedThirdPartiesControllerSpec extends SpecBase {
 
-  private val routeUrl  = AddedThirdPartiesController.onPageLoad(NormalMode, None).url
-  private val submitUrl = AddedThirdPartiesController.onSubmit(NormalMode).url
+  private def routeUrl: String  = AddedThirdPartiesController.onPageLoad(NormalMode, None).url
+  private def submitUrl: String = AddedThirdPartiesController.onSubmit(NormalMode).url
 
   private val tp1 = ThirdParty("1", Some("Org 1"))
   private val tp2 = ThirdParty("2", Some("Org 2"))
+
+  private val completeTp1 = completeThirdParty("1", "Org 1")
+  private val completeTp2 = completeThirdParty("2", "Org 2")
 
   private def journeyData(thirdParties: Seq[ThirdParty]) =
     testJourneyData.copy(
@@ -142,7 +145,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
 
       val maxList =
         (1 to mockAppConfig.maxThirdParties)
-          .map(i => ThirdParty(i.toString, Some(s"Org $i")))
+          .map(i => completeThirdParty(i.toString, s"Org $i"))
 
       val application =
         applicationBuilder(journeyData = Some(journeyData(maxList))).build()
@@ -193,7 +196,7 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
     "must redirect to 'Connected Third Parties' page when NO selected and more than one third party exists" in {
 
       val application =
-        applicationBuilder(journeyData = Some(journeyData(Seq(tp1, tp2)))).build()
+        applicationBuilder(journeyData = Some(journeyData(Seq(completeTp1, completeTp2)))).build()
 
       running(application) {
         val request =
@@ -204,6 +207,23 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual ThirdPartyConnectedOrganisationsController.onPageLoad(NormalMode).url
+      }
+    }
+
+    "must redirect to task list when NO selected and any third party is in progress" in {
+
+      val application =
+        applicationBuilder(journeyData = Some(journeyData(Seq(completeTp1, tp2)))).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, submitUrl)
+            .withFormUrlEncodedBody("value" -> YesNoAnswer.No.toString)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual TaskListController.onPageLoad().url
       }
     }
 
@@ -259,4 +279,12 @@ class AddedThirdPartiesControllerSpec extends SpecBase {
       }
     }
   }
+
+  private def completeThirdParty(id: String, name: String): ThirdParty =
+    ThirdParty(
+      id = id,
+      thirdPartyName = Some(name),
+      managingIsaReturns = Some(YesNoAnswer.No),
+      usingInvestorFunds = Some(YesNoAnswer.No)
+    )
 }

--- a/test/models/journeydata/thirdparty/ThirdPartySpec.scala
+++ b/test/models/journeydata/thirdparty/ThirdPartySpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.journeydata.thirdparty
+
+import base.SpecBase
+import models.YesNoAnswer
+
+class ThirdPartySpec extends SpecBase {
+
+  "ThirdParty.inProgress" - {
+
+    "must return false when required answers are complete and investor funds are not used" in {
+      val thirdParty =
+        ThirdParty(
+          id = "tp-1",
+          thirdPartyName = Some("Third Party Ltd"),
+          managingIsaReturns = Some(YesNoAnswer.No),
+          usingInvestorFunds = Some(YesNoAnswer.No)
+        )
+
+      thirdParty.inProgress mustBe false
+    }
+
+    "must return false when investor funds are used and the percentage has been answered" in {
+      val thirdParty =
+        ThirdParty(
+          id = "tp-1",
+          thirdPartyName = Some("Third Party Ltd"),
+          managingIsaReturns = Some(YesNoAnswer.No),
+          usingInvestorFunds = Some(YesNoAnswer.Yes),
+          investorFundsPercentage = Some("25")
+        )
+
+      thirdParty.inProgress mustBe false
+    }
+
+    "must return true when investor funds are used but the percentage has not been answered" in {
+      val thirdParty =
+        ThirdParty(
+          id = "tp-1",
+          thirdPartyName = Some("Third Party Ltd"),
+          managingIsaReturns = Some(YesNoAnswer.No),
+          usingInvestorFunds = Some(YesNoAnswer.Yes)
+        )
+
+      thirdParty.inProgress mustBe true
+    }
+
+    "must return true when a required answer is missing" in {
+      val thirdParty =
+        ThirdParty(
+          id = "tp-1",
+          thirdPartyName = Some("Third Party Ltd"),
+          managingIsaReturns = None,
+          usingInvestorFunds = Some(YesNoAnswer.No)
+        )
+
+      thirdParty.inProgress mustBe true
+    }
+  }
+}

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1309,8 +1309,6 @@ class NavigatorSpec extends SpecBase {
 
   "liaisonOfficerCheckRoute" - {
 
-    val id = "test-id"
-
     "must go to LO check answers when no returnTo is provided" in {
       val result =
         navigator.nextPageFromAddedLiaisonOfficers(YesNoAnswer.Yes, NormalMode, None)
@@ -1358,8 +1356,6 @@ class NavigatorSpec extends SpecBase {
   }
 
   "thirdPartyCheckModeRoute" - {
-
-    val id = "tp-1"
 
     "must go to Third Party check answers when no returnTo is provided" in {
       val result =

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -1513,6 +1513,21 @@ class NavigatorSpec extends SpecBase {
       result mustEqual ThirdPartyConnectedOrganisationsController.onPageLoad(NormalMode, None)
     }
 
+    "must go to TaskList when No and any third party is in progress" in {
+
+      val result =
+        navigator.nextPageFromAddedThirdParties(
+          answer = YesNoAnswer.No,
+          count = 2,
+          connectedOrganisations = Nil,
+          mode = NormalMode,
+          returnTo = None,
+          hasInProgressItems = true
+        )
+
+      result mustEqual TaskListController.onPageLoad()
+    }
+
     "must go to ThirdPartyConnectedOrganisations when No and returnTo = SubmissionCyaViaAddedThirdParties" in {
 
       val result =

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -18,14 +18,17 @@ package utils
 
 import generators.Generators
 import models.YesNoAnswer
-import models.journeydata.{BusinessVerification, CorrespondenceAddress, JourneyData, OrganisationDetails, RegisteredAddress}
+import models.journeydata.{BusinessVerification, CorrespondenceAddress, JourneyData, OrganisationDetails, OrganisationEmail, RegisteredAddress}
 import models.journeydata.certificatesofauthority.CertificatesOfAuthority
 import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.{No, Yes}
 import models.journeydata.certificatesofauthority.FcaArticles.Article14
 import models.journeydata.certificatesofauthority.FinancialOrganisation.EuropeanInstitution
+import models.journeydata.isaproducts.IsaProduct.CashIsas
 import models.journeydata.isaproducts.{InnovativeFinancialProduct, IsaProduct, IsaProducts}
+import models.journeydata.liaisonofficers.LiaisonOfficerCommunication.ByEmail
 import models.journeydata.liaisonofficers.{LiaisonOfficer, LiaisonOfficers}
 import models.journeydata.signatories.{Signatories, Signatory}
+import models.journeydata.thirdparty.{ThirdParty, ThirdPartyOrganisations}
 import uk.gov.hmrc.auth.core.User
 import uk.gov.hmrc.auth.core.retrieve.Credentials
 
@@ -69,6 +72,107 @@ trait TestData extends Generators {
   val testLiaisonOfficers = LiaisonOfficers(Seq(LiaisonOfficer(id = testString, fullName = Some(testString))))
 
   val testSignatories = Signatories(Seq(Signatory(id = testString, fullName = Some(testString))))
+
+  def emptyJourneyDataWithBusinessVerification: JourneyData =
+    emptyJourneyData.copy(businessVerification = Some(testBV))
+
+  def emptyJourneyDataWithFailedBusinessVerification: JourneyData =
+    emptyJourneyDataWithBusinessVerification.copy(
+      businessVerification = Some(testBV.copy(businessVerificationPassed = Some(false)))
+    )
+
+  val completeTaskListOrganisationDetails: OrganisationDetails =
+    OrganisationDetails(
+      registeredToManageIsa = Some(YesNoAnswer.No),
+      tradingUsingDifferentName = Some(YesNoAnswer.No),
+      fcaNumber = Some("123456"),
+      registeredAddressCorrespondence = Some(YesNoAnswer.Yes),
+      orgTelephoneNumber = Some("01234567890")
+    )
+
+  val inProgressTaskListOrganisationDetails: OrganisationDetails =
+    OrganisationDetails(registeredToManageIsa = Some(YesNoAnswer.Yes))
+
+  val completeTaskListOrganisationEmail: OrganisationEmail =
+    OrganisationEmail(Some("test@example.com"), Some(true))
+
+  val unverifiedTaskListOrganisationEmail: OrganisationEmail =
+    OrganisationEmail(Some("test@example.com"), Some(false))
+
+  val completeTaskListIsaProducts: IsaProducts =
+    IsaProducts(isaProducts = Some(Seq(CashIsas)))
+
+  val completeTaskListCertificatesOfAuthority: CertificatesOfAuthority =
+    CertificatesOfAuthority(certificatesYesNo = Some(Yes), fcaArticles = Some(Seq(Article14)))
+
+  def inProgressTaskListLiaisonOfficer(id: String, fullName: String = "Started"): LiaisonOfficer =
+    LiaisonOfficer(id, fullName = Some(fullName))
+
+  def completeTaskListLiaisonOfficer(id: String, fullName: String = "Complete Liaison Officer"): LiaisonOfficer =
+    LiaisonOfficer(
+      id = id,
+      fullName = Some(fullName),
+      phoneNumber = Some("01234567890"),
+      communication = Set(ByEmail),
+      email = Some("liaison@example.com")
+    )
+
+  def liaisonOfficersWith(liaisonOfficers: LiaisonOfficer*): LiaisonOfficers =
+    LiaisonOfficers(liaisonOfficers)
+
+  def inProgressTaskListSignatory(id: String, fullName: String = "Started"): Signatory =
+    Signatory(id, fullName = Some(fullName))
+
+  def completeTaskListSignatory(id: String, fullName: String = "Complete Signatory"): Signatory =
+    Signatory(
+      id = id,
+      fullName = Some(fullName),
+      jobTitle = Some("Director")
+    )
+
+  def signatoriesWith(signatories: Signatory*): Signatories =
+    Signatories(signatories)
+
+  def inProgressTaskListThirdParty(id: String, name: String = "Started"): ThirdParty =
+    ThirdParty(id, thirdPartyName = Some(name))
+
+  def completeTaskListThirdParty(id: String, name: String = "Complete Third Party"): ThirdParty =
+    ThirdParty(
+      id = id,
+      thirdPartyName = Some(name),
+      managingIsaReturns = Some(YesNoAnswer.No),
+      usingInvestorFunds = Some(YesNoAnswer.No)
+    )
+
+  val thirdPartyOrganisationsNotUsed: ThirdPartyOrganisations =
+    ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No))
+
+  def testThirdPartyOrganisations(
+    thirdParties: Seq[ThirdParty],
+    managedByThirdParty: YesNoAnswer = YesNoAnswer.Yes,
+    connectedOrganisations: Seq[String] = Seq.empty
+  ): ThirdPartyOrganisations =
+    ThirdPartyOrganisations(
+      managedByThirdParty = Some(managedByThirdParty),
+      thirdParties = thirdParties,
+      connectedOrganisations = connectedOrganisations
+    )
+
+  def journeyDataWithThirdParties(thirdParties: Seq[ThirdParty]): JourneyData =
+    testJourneyData.copy(
+      thirdPartyOrganisations = Some(testThirdPartyOrganisations(thirdParties))
+    )
+
+  def completeTaskListJourneyData: JourneyData =
+    emptyJourneyDataWithBusinessVerification.copy(
+      organisationDetails = Some(completeTaskListOrganisationDetails),
+      organisationEmail = Some(completeTaskListOrganisationEmail),
+      isaProducts = Some(completeTaskListIsaProducts),
+      certificatesOfAuthority = Some(completeTaskListCertificatesOfAuthority),
+      liaisonOfficers = Some(LiaisonOfficers(Seq(completeTaskListLiaisonOfficer("lo-1")))),
+      signatories = Some(Signatories(Seq(completeTaskListSignatory("sig-1")))),
+      thirdPartyOrganisations = Some(thirdPartyOrganisationsNotUsed)
+    )
 
   val testJourneyData: JourneyData =
     JourneyData(

--- a/test/viewmodels/tasklist/TaskListViewModelSpec.scala
+++ b/test/viewmodels/tasklist/TaskListViewModelSpec.scala
@@ -17,17 +17,6 @@
 package viewmodels.tasklist
 
 import base.SpecBase
-import models.YesNoAnswer
-import models.journeydata.certificatesofauthority.CertificatesOfAuthority
-import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.Yes as CertificatesYes
-import models.journeydata.certificatesofauthority.FcaArticles.Article14
-import models.journeydata.isaproducts.IsaProduct.CashIsas
-import models.journeydata.isaproducts.IsaProducts
-import models.journeydata.liaisonofficers.LiaisonOfficerCommunication.ByEmail
-import models.journeydata.liaisonofficers.{LiaisonOfficer, LiaisonOfficers}
-import models.journeydata.signatories.{Signatories, Signatory}
-import models.journeydata.thirdparty.{ThirdParty, ThirdPartyOrganisations}
-import models.journeydata.{JourneyData, OrganisationDetails, OrganisationEmail}
 import uk.gov.hmrc.auth.core.{Assistant, User}
 
 class TaskListViewModelSpec extends SpecBase {
@@ -35,7 +24,7 @@ class TaskListViewModelSpec extends SpecBase {
   "TaskListViewModel" - {
 
     "must lock all tasks except organisation information until organisation information is complete" in {
-      val viewModel = TaskListViewModel(emptyJourneyDataWithBv, User)
+      val viewModel = TaskListViewModel(emptyJourneyDataWithBusinessVerification, User)
 
       task(viewModel, "taskList.organisationInformation.add").href.value mustBe
         controllers.orgdetails.routes.RegisteredIsaManagerController.onPageLoad(models.NormalMode).url
@@ -61,8 +50,8 @@ class TaskListViewModelSpec extends SpecBase {
     }
 
     "must show organisation information in progress while keeping remaining tasks locked" in {
-      val journeyData = emptyJourneyDataWithBv.copy(
-        organisationDetails = Some(OrganisationDetails(registeredToManageIsa = Some(YesNoAnswer.Yes)))
+      val journeyData = emptyJourneyDataWithBusinessVerification.copy(
+        organisationDetails = Some(inProgressTaskListOrganisationDetails)
       )
 
       val viewModel = TaskListViewModel(journeyData, User)
@@ -77,7 +66,12 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must unlock remaining tasks once organisation information is complete" in {
       val viewModel =
-        TaskListViewModel(emptyJourneyDataWithBv.copy(organisationDetails = Some(completeOrgDetails)), User)
+        TaskListViewModel(
+          emptyJourneyDataWithBusinessVerification.copy(organisationDetails =
+            Some(completeTaskListOrganisationDetails)
+          ),
+          User
+        )
 
       task(viewModel, "taskList.organisationInformation.change").status.content mustBe messages(
         "taskList.status.completed"
@@ -101,9 +95,9 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must show not verified for an unverified organisation email" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
-          organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(false)))
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
+          organisationEmail = Some(unverifiedTaskListOrganisationEmail)
         ),
         User
       )
@@ -116,7 +110,12 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must route empty multi-item tasks to the first question" in {
       val viewModel =
-        TaskListViewModel(emptyJourneyDataWithBv.copy(organisationDetails = Some(completeOrgDetails)), User)
+        TaskListViewModel(
+          emptyJourneyDataWithBusinessVerification.copy(organisationDetails =
+            Some(completeTaskListOrganisationDetails)
+          ),
+          User
+        )
 
       task(viewModel, "taskList.liaisonOfficers.add").href.value mustBe
         controllers.liaisonofficers.routes.LiaisonOfficerNameController
@@ -134,16 +133,12 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must route multi-item tasks with existing items to their multiple item CYA pages" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
-          liaisonOfficers = Some(LiaisonOfficers(Seq(LiaisonOfficer("lo-1", fullName = Some("Started"))))),
-          signatories = Some(Signatories(Seq(Signatory("sig-1", fullName = Some("Started"))))),
-          thirdPartyOrganisations = Some(
-            ThirdPartyOrganisations(
-              managedByThirdParty = Some(YesNoAnswer.Yes),
-              thirdParties = Seq(ThirdParty("third-party-1", thirdPartyName = Some("Started")))
-            )
-          )
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
+          liaisonOfficers = Some(liaisonOfficersWith(inProgressTaskListLiaisonOfficer("lo-1"))),
+          signatories = Some(signatoriesWith(inProgressTaskListSignatory("sig-1"))),
+          thirdPartyOrganisations =
+            Some(testThirdPartyOrganisations(Seq(inProgressTaskListThirdParty("third-party-1"))))
         ),
         User
       )
@@ -158,12 +153,11 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must route multiple completed third party organisations to the section final CYA" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
           thirdPartyOrganisations = Some(
-            ThirdPartyOrganisations(
-              managedByThirdParty = Some(YesNoAnswer.Yes),
-              thirdParties = Seq(completeThirdParty("third-party-1"), completeThirdParty("third-party-2"))
+            testThirdPartyOrganisations(
+              Seq(completeTaskListThirdParty("third-party-1"), completeTaskListThirdParty("third-party-2"))
             )
           )
         ),
@@ -176,30 +170,22 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must show in progress when authorised users or third parties include incomplete records" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
           liaisonOfficers = Some(
-            LiaisonOfficers(
-              Seq(
-                LiaisonOfficer("lo-1", fullName = Some("Started")),
-                completeLiaisonOfficer("lo-2")
-              )
+            liaisonOfficersWith(
+              inProgressTaskListLiaisonOfficer("lo-1"),
+              completeTaskListLiaisonOfficer("lo-2")
             )
           ),
           signatories = Some(
-            Signatories(
-              Seq(
-                Signatory("sig-1", fullName = Some("Started")),
-                completeSignatory("sig-2")
-              )
+            signatoriesWith(
+              inProgressTaskListSignatory("sig-1"),
+              completeTaskListSignatory("sig-2")
             )
           ),
-          thirdPartyOrganisations = Some(
-            ThirdPartyOrganisations(
-              managedByThirdParty = Some(YesNoAnswer.Yes),
-              thirdParties = Seq(ThirdParty("third-party-1", thirdPartyName = Some("Started")))
-            )
-          )
+          thirdPartyOrganisations =
+            Some(testThirdPartyOrganisations(Seq(inProgressTaskListThirdParty("third-party-1"))))
         ),
         User
       )
@@ -218,14 +204,15 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must count authorised users and third parties when all records are complete" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
-          liaisonOfficers = Some(LiaisonOfficers(Seq(completeLiaisonOfficer("lo-1"), completeLiaisonOfficer("lo-2")))),
-          signatories = Some(Signatories(Seq(completeSignatory("sig-1"), completeSignatory("sig-2")))),
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
+          liaisonOfficers = Some(
+            liaisonOfficersWith(completeTaskListLiaisonOfficer("lo-1"), completeTaskListLiaisonOfficer("lo-2"))
+          ),
+          signatories = Some(signatoriesWith(completeTaskListSignatory("sig-1"), completeTaskListSignatory("sig-2"))),
           thirdPartyOrganisations = Some(
-            ThirdPartyOrganisations(
-              managedByThirdParty = Some(YesNoAnswer.Yes),
-              thirdParties = Seq(completeThirdParty("third-party-1"), completeThirdParty("third-party-2"))
+            testThirdPartyOrganisations(
+              Seq(completeTaskListThirdParty("third-party-1"), completeTaskListThirdParty("third-party-2"))
             )
           )
         ),
@@ -242,9 +229,9 @@ class TaskListViewModelSpec extends SpecBase {
 
     "must mark third party organisations complete without a count when the answer is no" in {
       val viewModel = TaskListViewModel(
-        emptyJourneyDataWithBv.copy(
-          organisationDetails = Some(completeOrgDetails),
-          thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
+        emptyJourneyDataWithBusinessVerification.copy(
+          organisationDetails = Some(completeTaskListOrganisationDetails),
+          thirdPartyOrganisations = Some(thirdPartyOrganisationsNotUsed)
         ),
         User
       )
@@ -255,7 +242,7 @@ class TaskListViewModelSpec extends SpecBase {
     }
 
     "must allow administrators to submit only when all required tasks are complete" in {
-      val journeyData = completeJourneyData
+      val journeyData = completeTaskListJourneyData
       val viewModel   = TaskListViewModel(journeyData, User)
 
       viewModel.canSubmitAnswers mustBe true
@@ -268,74 +255,23 @@ class TaskListViewModelSpec extends SpecBase {
     }
 
     "must prevent assistants from submitting final answers" in {
-      val viewModel = TaskListViewModel(completeJourneyData, Assistant)
+      val viewModel = TaskListViewModel(completeTaskListJourneyData, Assistant)
 
       viewModel.canSubmitAnswers mustBe false
       val row = task(viewModel, "taskList.submit.assistantCannotSubmit")
 
       row.href mustBe None
       row.status.toGovuk mustBe uk.gov.hmrc.govukfrontend.views.viewmodels.tasklist.TaskListItemStatus()
-      TaskListViewModel.canSubmitAnswers(completeJourneyData, Assistant) mustBe false
+      TaskListViewModel.canSubmitAnswers(completeTaskListJourneyData, Assistant) mustBe false
     }
 
     "must require successful business verification before the task list can be accessed" in {
       TaskListViewModel.canAccessTaskList(emptyJourneyData) mustBe false
-      TaskListViewModel.canAccessTaskList(emptyJourneyDataWithBv) mustBe true
-      TaskListViewModel.canAccessTaskList(
-        emptyJourneyDataWithBv.copy(businessVerification = Some(testBV.copy(businessVerificationPassed = Some(false))))
-      ) mustBe false
+      TaskListViewModel.canAccessTaskList(emptyJourneyDataWithBusinessVerification) mustBe true
+      TaskListViewModel.canAccessTaskList(emptyJourneyDataWithFailedBusinessVerification) mustBe false
     }
   }
 
   private def task(viewModel: TaskListViewModel, titleMessageKey: String): TaskListTaskViewModel =
     viewModel.sections.flatMap(_.tasks).find(_.title == messages(titleMessageKey)).value
-
-  private def emptyJourneyDataWithBv: JourneyData =
-    emptyJourneyData.copy(businessVerification = Some(testBV))
-
-  private def completeJourneyData: JourneyData =
-    emptyJourneyDataWithBv.copy(
-      organisationDetails = Some(completeOrgDetails),
-      organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(true))),
-      isaProducts = Some(IsaProducts(isaProducts = Some(Seq(CashIsas)))),
-      certificatesOfAuthority = Some(
-        CertificatesOfAuthority(certificatesYesNo = Some(CertificatesYes), fcaArticles = Some(Seq(Article14)))
-      ),
-      liaisonOfficers = Some(LiaisonOfficers(Seq(completeLiaisonOfficer("lo-1")))),
-      signatories = Some(Signatories(Seq(completeSignatory("sig-1")))),
-      thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
-    )
-
-  private val completeOrgDetails: OrganisationDetails =
-    OrganisationDetails(
-      registeredToManageIsa = Some(YesNoAnswer.No),
-      tradingUsingDifferentName = Some(YesNoAnswer.No),
-      fcaNumber = Some("123456"),
-      registeredAddressCorrespondence = Some(YesNoAnswer.Yes),
-      orgTelephoneNumber = Some("01234567890")
-    )
-
-  private def completeLiaisonOfficer(id: String): LiaisonOfficer =
-    LiaisonOfficer(
-      id = id,
-      fullName = Some("Complete Liaison Officer"),
-      phoneNumber = Some("01234567890"),
-      communication = Set(ByEmail),
-      email = Some("liaison@example.com")
-    )
-
-  private def completeSignatory(id: String): Signatory =
-    Signatory(
-      id = id,
-      fullName = Some("Complete Signatory"),
-      jobTitle = Some("Director")
-    )
-
-  private def completeThirdParty(id: String): ThirdParty =
-    ThirdParty(
-      id = id,
-      thirdPartyName = Some("Complete Third Party"),
-      managingIsaReturns = Some(YesNoAnswer.No),
-      usingInvestorFunds = Some(YesNoAnswer.No)
-    )
 }

--- a/test/viewmodels/tasklist/TaskListViewModelSpec.scala
+++ b/test/viewmodels/tasklist/TaskListViewModelSpec.scala
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.tasklist
+
+import base.SpecBase
+import models.YesNoAnswer
+import models.journeydata.certificatesofauthority.CertificatesOfAuthority
+import models.journeydata.certificatesofauthority.CertificatesOfAuthorityYesNo.Yes as CertificatesYes
+import models.journeydata.certificatesofauthority.FcaArticles.Article14
+import models.journeydata.isaproducts.IsaProduct.CashIsas
+import models.journeydata.isaproducts.IsaProducts
+import models.journeydata.liaisonofficers.LiaisonOfficerCommunication.ByEmail
+import models.journeydata.liaisonofficers.{LiaisonOfficer, LiaisonOfficers}
+import models.journeydata.signatories.{Signatories, Signatory}
+import models.journeydata.thirdparty.{ThirdParty, ThirdPartyOrganisations}
+import models.journeydata.{JourneyData, OrganisationDetails, OrganisationEmail}
+import uk.gov.hmrc.auth.core.{Assistant, User}
+
+class TaskListViewModelSpec extends SpecBase {
+
+  "TaskListViewModel" - {
+
+    "must lock all tasks except organisation information until organisation information is complete" in {
+      val viewModel = TaskListViewModel(emptyJourneyDataWithBv, User)
+
+      task(viewModel, "taskList.organisationInformation.add").href.value mustBe
+        controllers.orgdetails.routes.RegisteredIsaManagerController.onPageLoad(models.NormalMode).url
+      task(viewModel, "taskList.organisationInformation.add").status.content mustBe messages(
+        "taskList.status.notYetStarted"
+      )
+      task(viewModel, "taskList.organisationInformation.add").status.tagClass mustBe Some("govuk-tag--blue")
+
+      Seq(
+        "taskList.organisationEmail.add",
+        "taskList.isaProducts.add",
+        "taskList.certificatesOfAuthority.add",
+        "taskList.liaisonOfficers.add",
+        "taskList.signatories.add",
+        "taskList.thirdPartyOrganisations.add",
+        "taskList.submit.checkAnswers"
+      ).foreach { messageKey =>
+        val row = task(viewModel, messageKey)
+
+        row.href mustBe None
+        row.status.content mustBe messages("taskList.status.cannotStartYet")
+      }
+    }
+
+    "must show organisation information in progress while keeping remaining tasks locked" in {
+      val journeyData = emptyJourneyDataWithBv.copy(
+        organisationDetails = Some(OrganisationDetails(registeredToManageIsa = Some(YesNoAnswer.Yes)))
+      )
+
+      val viewModel = TaskListViewModel(journeyData, User)
+
+      task(viewModel, "taskList.organisationInformation.add").status.content mustBe messages(
+        "taskList.status.inProgress"
+      )
+      task(viewModel, "taskList.organisationInformation.add").status.tagClass mustBe Some("govuk-tag--blue")
+      task(viewModel, "taskList.organisationEmail.add").href mustBe None
+      task(viewModel, "taskList.organisationEmail.add").status.content mustBe messages("taskList.status.cannotStartYet")
+    }
+
+    "must unlock remaining tasks once organisation information is complete" in {
+      val viewModel =
+        TaskListViewModel(emptyJourneyDataWithBv.copy(organisationDetails = Some(completeOrgDetails)), User)
+
+      task(viewModel, "taskList.organisationInformation.change").status.content mustBe messages(
+        "taskList.status.completed"
+      )
+
+      Seq(
+        "taskList.organisationEmail.add",
+        "taskList.isaProducts.add",
+        "taskList.certificatesOfAuthority.add",
+        "taskList.liaisonOfficers.add",
+        "taskList.signatories.add",
+        "taskList.thirdPartyOrganisations.add"
+      ).foreach { messageKey =>
+        val row = task(viewModel, messageKey)
+
+        row.href must not be empty
+        row.status.content mustBe messages("taskList.status.notYetStarted")
+        row.status.tagClass mustBe Some("govuk-tag--blue")
+      }
+    }
+
+    "must show not verified for an unverified organisation email" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(false)))
+        ),
+        User
+      )
+
+      val row = task(viewModel, "taskList.organisationEmail.add")
+
+      row.status.content mustBe messages("taskList.status.notVerified")
+      row.status.tagClass mustBe Some("govuk-tag--yellow")
+    }
+
+    "must route empty multi-item tasks to the first question" in {
+      val viewModel =
+        TaskListViewModel(emptyJourneyDataWithBv.copy(organisationDetails = Some(completeOrgDetails)), User)
+
+      task(viewModel, "taskList.liaisonOfficers.add").href.value mustBe
+        controllers.liaisonofficers.routes.LiaisonOfficerNameController
+          .onPageLoad(id = None, mode = models.NormalMode, returnTo = None)
+          .url
+      task(viewModel, "taskList.signatories.add").href.value mustBe
+        controllers.signatories.routes.SignatoryNameController
+          .onPageLoad(id = None, mode = models.NormalMode, returnTo = None)
+          .url
+      task(viewModel, "taskList.thirdPartyOrganisations.add").href.value mustBe
+        controllers.thirdparty.routes.ProductsManagedByThirdPartyController
+          .onPageLoad(models.NormalMode)
+          .url
+    }
+
+    "must route multi-item tasks with existing items to their multiple item CYA pages" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          liaisonOfficers = Some(LiaisonOfficers(Seq(LiaisonOfficer("lo-1", fullName = Some("Started"))))),
+          signatories = Some(Signatories(Seq(Signatory("sig-1", fullName = Some("Started"))))),
+          thirdPartyOrganisations = Some(
+            ThirdPartyOrganisations(
+              managedByThirdParty = Some(YesNoAnswer.Yes),
+              thirdParties = Seq(ThirdParty("third-party-1", thirdPartyName = Some("Started")))
+            )
+          )
+        ),
+        User
+      )
+
+      task(viewModel, "taskList.liaisonOfficers.change").href.value mustBe
+        controllers.liaisonofficers.routes.AddedLiaisonOfficersController.onPageLoad(models.NormalMode).url
+      task(viewModel, "taskList.signatories.change").href.value mustBe
+        controllers.signatories.routes.AddedSignatoryController.onPageLoad(models.NormalMode).url
+      task(viewModel, "taskList.thirdPartyOrganisations.change").href.value mustBe
+        controllers.thirdparty.routes.AddedThirdPartiesController.onPageLoad(models.NormalMode).url
+    }
+
+    "must route multiple completed third party organisations to the section final CYA" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          thirdPartyOrganisations = Some(
+            ThirdPartyOrganisations(
+              managedByThirdParty = Some(YesNoAnswer.Yes),
+              thirdParties = Seq(completeThirdParty("third-party-1"), completeThirdParty("third-party-2"))
+            )
+          )
+        ),
+        User
+      )
+
+      task(viewModel, "taskList.thirdPartyOrganisations.change").href.value mustBe
+        controllers.thirdparty.routes.ThirdPartiesCheckYourAnswersController.onPageLoad().url
+    }
+
+    "must show in progress when authorised users or third parties include incomplete records" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          liaisonOfficers = Some(
+            LiaisonOfficers(
+              Seq(
+                LiaisonOfficer("lo-1", fullName = Some("Started")),
+                completeLiaisonOfficer("lo-2")
+              )
+            )
+          ),
+          signatories = Some(
+            Signatories(
+              Seq(
+                Signatory("sig-1", fullName = Some("Started")),
+                completeSignatory("sig-2")
+              )
+            )
+          ),
+          thirdPartyOrganisations = Some(
+            ThirdPartyOrganisations(
+              managedByThirdParty = Some(YesNoAnswer.Yes),
+              thirdParties = Seq(ThirdParty("third-party-1", thirdPartyName = Some("Started")))
+            )
+          )
+        ),
+        User
+      )
+
+      Seq(
+        "taskList.liaisonOfficers.change",
+        "taskList.signatories.change",
+        "taskList.thirdPartyOrganisations.change"
+      ).foreach { messageKey =>
+        val row = task(viewModel, messageKey)
+
+        row.status.content mustBe messages("taskList.status.inProgress")
+        row.status.tagClass mustBe Some("govuk-tag--blue")
+      }
+    }
+
+    "must count authorised users and third parties when all records are complete" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          liaisonOfficers = Some(LiaisonOfficers(Seq(completeLiaisonOfficer("lo-1"), completeLiaisonOfficer("lo-2")))),
+          signatories = Some(Signatories(Seq(completeSignatory("sig-1"), completeSignatory("sig-2")))),
+          thirdPartyOrganisations = Some(
+            ThirdPartyOrganisations(
+              managedByThirdParty = Some(YesNoAnswer.Yes),
+              thirdParties = Seq(completeThirdParty("third-party-1"), completeThirdParty("third-party-2"))
+            )
+          )
+        ),
+        User
+      )
+
+      task(viewModel, "taskList.liaisonOfficers.change").status.content mustBe
+        messages(app)("taskList.count.liaisonOfficer.other", 2)
+      task(viewModel, "taskList.signatories.change").status.content mustBe
+        messages(app)("taskList.count.signatory.other", 2)
+      task(viewModel, "taskList.thirdPartyOrganisations.change").status.content mustBe
+        messages(app)("taskList.count.thirdParty.other", 2)
+    }
+
+    "must mark third party organisations complete without a count when the answer is no" in {
+      val viewModel = TaskListViewModel(
+        emptyJourneyDataWithBv.copy(
+          organisationDetails = Some(completeOrgDetails),
+          thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
+        ),
+        User
+      )
+
+      task(viewModel, "taskList.thirdPartyOrganisations.change").status.content mustBe messages(
+        "taskList.status.completed"
+      )
+    }
+
+    "must allow administrators to submit only when all required tasks are complete" in {
+      val journeyData = completeJourneyData
+      val viewModel   = TaskListViewModel(journeyData, User)
+
+      viewModel.canSubmitAnswers mustBe true
+      task(viewModel, "taskList.submit.checkAnswers").href.value mustBe controllers.routes.SubmissionCyaController
+        .onPageLoad()
+        .url
+      task(viewModel, "taskList.submit.checkAnswers").status.content mustBe messages("taskList.status.notYetStarted")
+      TaskListViewModel.canSubmitAnswers(journeyData, User) mustBe true
+      TaskListViewModel.canSubmitAnswers(journeyData.copy(businessVerification = None), User) mustBe false
+    }
+
+    "must prevent assistants from submitting final answers" in {
+      val viewModel = TaskListViewModel(completeJourneyData, Assistant)
+
+      viewModel.canSubmitAnswers mustBe false
+      val row = task(viewModel, "taskList.submit.assistantCannotSubmit")
+
+      row.href mustBe None
+      row.status.toGovuk mustBe uk.gov.hmrc.govukfrontend.views.viewmodels.tasklist.TaskListItemStatus()
+      TaskListViewModel.canSubmitAnswers(completeJourneyData, Assistant) mustBe false
+    }
+
+    "must require successful business verification before the task list can be accessed" in {
+      TaskListViewModel.canAccessTaskList(emptyJourneyData) mustBe false
+      TaskListViewModel.canAccessTaskList(emptyJourneyDataWithBv) mustBe true
+      TaskListViewModel.canAccessTaskList(
+        emptyJourneyDataWithBv.copy(businessVerification = Some(testBV.copy(businessVerificationPassed = Some(false))))
+      ) mustBe false
+    }
+  }
+
+  private def task(viewModel: TaskListViewModel, titleMessageKey: String): TaskListTaskViewModel =
+    viewModel.sections.flatMap(_.tasks).find(_.title == messages(titleMessageKey)).value
+
+  private def emptyJourneyDataWithBv: JourneyData =
+    emptyJourneyData.copy(businessVerification = Some(testBV))
+
+  private def completeJourneyData: JourneyData =
+    emptyJourneyDataWithBv.copy(
+      organisationDetails = Some(completeOrgDetails),
+      organisationEmail = Some(OrganisationEmail(Some("test@example.com"), Some(true))),
+      isaProducts = Some(IsaProducts(isaProducts = Some(Seq(CashIsas)))),
+      certificatesOfAuthority = Some(
+        CertificatesOfAuthority(certificatesYesNo = Some(CertificatesYes), fcaArticles = Some(Seq(Article14)))
+      ),
+      liaisonOfficers = Some(LiaisonOfficers(Seq(completeLiaisonOfficer("lo-1")))),
+      signatories = Some(Signatories(Seq(completeSignatory("sig-1")))),
+      thirdPartyOrganisations = Some(ThirdPartyOrganisations(managedByThirdParty = Some(YesNoAnswer.No)))
+    )
+
+  private val completeOrgDetails: OrganisationDetails =
+    OrganisationDetails(
+      registeredToManageIsa = Some(YesNoAnswer.No),
+      tradingUsingDifferentName = Some(YesNoAnswer.No),
+      fcaNumber = Some("123456"),
+      registeredAddressCorrespondence = Some(YesNoAnswer.Yes),
+      orgTelephoneNumber = Some("01234567890")
+    )
+
+  private def completeLiaisonOfficer(id: String): LiaisonOfficer =
+    LiaisonOfficer(
+      id = id,
+      fullName = Some("Complete Liaison Officer"),
+      phoneNumber = Some("01234567890"),
+      communication = Set(ByEmail),
+      email = Some("liaison@example.com")
+    )
+
+  private def completeSignatory(id: String): Signatory =
+    Signatory(
+      id = id,
+      fullName = Some("Complete Signatory"),
+      jobTitle = Some("Director")
+    )
+
+  private def completeThirdParty(id: String): ThirdParty =
+    ThirdParty(
+      id = id,
+      thirdPartyName = Some("Complete Third Party"),
+      managingIsaReturns = Some(YesNoAnswer.No),
+      usingInvestorFunds = Some(YesNoAnswer.No)
+    )
+}

--- a/test/viewmodels/tasklist/TaskListViewModelSpec.scala
+++ b/test/viewmodels/tasklist/TaskListViewModelSpec.scala
@@ -23,7 +23,7 @@ class TaskListViewModelSpec extends SpecBase {
 
   "TaskListViewModel" - {
 
-    "must lock all tasks except organisation information until organisation information is complete" in {
+    "must unlock all task sections except submit after successful business verification" in {
       val viewModel = TaskListViewModel(emptyJourneyDataWithBusinessVerification, User)
 
       task(viewModel, "taskList.organisationInformation.add").href.value mustBe
@@ -39,17 +39,21 @@ class TaskListViewModelSpec extends SpecBase {
         "taskList.certificatesOfAuthority.add",
         "taskList.liaisonOfficers.add",
         "taskList.signatories.add",
-        "taskList.thirdPartyOrganisations.add",
-        "taskList.submit.checkAnswers"
+        "taskList.thirdPartyOrganisations.add"
       ).foreach { messageKey =>
         val row = task(viewModel, messageKey)
 
-        row.href mustBe None
-        row.status.content mustBe messages("taskList.status.cannotStartYet")
+        row.href must not be empty
+        row.status.content mustBe messages("taskList.status.notYetStarted")
+        row.status.tagClass mustBe Some("govuk-tag--blue")
       }
+
+      val submitRow = task(viewModel, "taskList.submit.checkAnswers")
+      submitRow.href mustBe None
+      submitRow.status.content mustBe messages("taskList.status.cannotStartYet")
     }
 
-    "must show organisation information in progress while keeping remaining tasks locked" in {
+    "must show organisation information in progress while keeping remaining task sections accessible" in {
       val journeyData = emptyJourneyDataWithBusinessVerification.copy(
         organisationDetails = Some(inProgressTaskListOrganisationDetails)
       )
@@ -60,11 +64,11 @@ class TaskListViewModelSpec extends SpecBase {
         "taskList.status.inProgress"
       )
       task(viewModel, "taskList.organisationInformation.add").status.tagClass mustBe Some("govuk-tag--blue")
-      task(viewModel, "taskList.organisationEmail.add").href mustBe None
-      task(viewModel, "taskList.organisationEmail.add").status.content mustBe messages("taskList.status.cannotStartYet")
+      task(viewModel, "taskList.organisationEmail.add").href must not be empty
+      task(viewModel, "taskList.organisationEmail.add").status.content mustBe messages("taskList.status.notYetStarted")
     }
 
-    "must unlock remaining tasks once organisation information is complete" in {
+    "must mark organisation information complete while keeping other incomplete sections accessible" in {
       val viewModel =
         TaskListViewModel(
           emptyJourneyDataWithBusinessVerification.copy(organisationDetails =


### PR DESCRIPTION
Be advised some commits not strictly related to the ticket. 
- One is related to allowing CTEnrolled as positive BV result.
- ServiceUrl should go tot task list
- Redirect to start controller if required data is missing.
- CoA CYA button now navigates to task-list.
- Print page script didn't get merged for 1855 so adding it here.
- Navigation for third-party Add another page now redirects to task-list if there are any in-progress third party items (confirmed with Rachel)