### PR TITLE
DFI-2040 Correct backlink navigation on IDed page flows

### DIFF
--- a/app/controllers/liaisonofficers/LiaisonOfficerNameController.scala
+++ b/app/controllers/liaisonofficers/LiaisonOfficerNameController.scala
@@ -63,11 +63,39 @@ class LiaisonOfficerNameController @Inject() (
   def onPageLoad(id: Option[String], mode: Mode, returnTo: Option[ReturnTo]): Action[AnyContent] =
     (identify andThen getData andThen requireData andThen auditContinuation(LiaisonOfficers.sectionName)) {
       implicit request =>
-        existingOfficer(id) match {
-          case Some(officer) => Ok(view(officer.id, form.fill(officer.fullName.getOrElse("")), mode, returnTo))
-          case None          =>
-            if (canAddAnother(appConfig)) Ok(view(uuidGenerator.generate(), form, mode, returnTo))
-            else Redirect(TaskListController.onPageLoad())
+        id match {
+
+          case None =>
+            if (canAddAnother(appConfig)) {
+              Redirect(
+                routes.LiaisonOfficerNameController.onPageLoad(
+                  Some(uuidGenerator.generate()),
+                  mode,
+                  returnTo
+                )
+              )
+            } else {
+              Redirect(TaskListController.onPageLoad())
+            }
+
+          case Some(existingId) =>
+            existingOfficer(id) match {
+              case Some(officer) =>
+                Ok(
+                  view(
+                    officer.id,
+                    form.fill(officer.fullName.getOrElse("")),
+                    mode,
+                    returnTo
+                  )
+                )
+
+              case None =>
+                if (canAddAnother(appConfig))
+                  Ok(view(existingId, form, mode, returnTo))
+                else
+                  Redirect(TaskListController.onPageLoad())
+            }
         }
     }
 

--- a/app/controllers/liaisonofficers/LiaisonOfficerNameController.scala
+++ b/app/controllers/liaisonofficers/LiaisonOfficerNameController.scala
@@ -64,38 +64,21 @@ class LiaisonOfficerNameController @Inject() (
     (identify andThen getData andThen requireData andThen auditContinuation(LiaisonOfficers.sectionName)) {
       implicit request =>
         id match {
-
           case None =>
             if (canAddAnother(appConfig)) {
-              Redirect(
-                routes.LiaisonOfficerNameController.onPageLoad(
-                  Some(uuidGenerator.generate()),
-                  mode,
-                  returnTo
-                )
-              )
+              Redirect(routes.LiaisonOfficerNameController.onPageLoad(Some(uuidGenerator.generate()), mode, returnTo))
             } else {
               Redirect(TaskListController.onPageLoad())
             }
 
           case Some(existingId) =>
-            existingOfficer(id) match {
-              case Some(officer) =>
-                Ok(
-                  view(
-                    officer.id,
-                    form.fill(officer.fullName.getOrElse("")),
-                    mode,
-                    returnTo
-                  )
-                )
+            val preparedForm =
+              existingOfficer(id) match {
+                case Some(officer) => form.fill(officer.fullName.getOrElse(""))
+                case None          => form
+              }
 
-              case None =>
-                if (canAddAnother(appConfig))
-                  Ok(view(existingId, form, mode, returnTo))
-                else
-                  Redirect(TaskListController.onPageLoad())
-            }
+            Ok(view(existingId, preparedForm, mode, returnTo))
         }
     }
 

--- a/app/controllers/signatories/SignatoryNameController.scala
+++ b/app/controllers/signatories/SignatoryNameController.scala
@@ -63,18 +63,23 @@ class SignatoryNameController @Inject() (
   def onPageLoad(id: Option[String], mode: Mode, returnTo: Option[ReturnTo]): Action[AnyContent] =
     (identify andThen getData andThen requireData andThen auditContinuation(Signatories.sectionName)) {
       implicit request =>
-        if (id.isEmpty && signatoryCount(request) >= appConfig.maxSignatories) {
-          Redirect(TaskListController.onPageLoad())
-        } else {
-          val preparedFormAndId = (for {
-            id          <- id
-            signatories <- request.journeyData.signatories.map(_.signatories)
-            signatory   <- signatories.find(_.id == id)
-            name        <- signatory.fullName
-          } yield (form.fill(name), id))
-            .getOrElse((form, uuidGenerator.generate()))
+        id match {
+          case None             =>
+            if (signatoryCount(request) >= appConfig.maxSignatories) {
+              Redirect(TaskListController.onPageLoad())
+            } else {
+              Redirect(routes.SignatoryNameController.onPageLoad(Some(uuidGenerator.generate()), mode, returnTo))
+            }
+          case Some(existingId) =>
+            val preparedFormAndId =
+              (for {
+                signatories <- request.journeyData.signatories.map(_.signatories)
+                signatory   <- signatories.find(_.id == existingId)
+                name        <- signatory.fullName
+              } yield (form.fill(name), existingId))
+                .getOrElse((form, existingId))
 
-          Ok(view(preparedFormAndId._2, preparedFormAndId._1, mode, returnTo))
+            Ok(view(preparedFormAndId._2, preparedFormAndId._1, mode, returnTo))
         }
     }
 

--- a/app/controllers/thirdparty/ThirdPartyOrgDetailsController.scala
+++ b/app/controllers/thirdparty/ThirdPartyOrgDetailsController.scala
@@ -61,19 +61,31 @@ class ThirdPartyOrgDetailsController @Inject() (
 
   def onPageLoad(id: Option[String], mode: Mode, returnTo: Option[ReturnTo]): Action[AnyContent] =
     (identify andThen getData andThen requireData) { implicit request =>
-      if (cannotAddAnotherThirdParty(id, request)) {
-        Redirect(TaskListController.onPageLoad())
-      } else {
-        val preparedFormAndId = (for {
-          id           <- id
-          thirdParties <- request.journeyData.thirdPartyOrganisations.map(_.thirdParties)
-          thirdParty   <- thirdParties.find(_.id == id)
-          name         <- thirdParty.thirdPartyName
-          frn           = thirdParty.thirdPartyFrn
-        } yield (form.fill(ThirdPartyOrgDetailsForm(name, frn)), id))
-          .getOrElse((form, uuidGenerator.generate()))
+      id match {
+        case None =>
+          if (cannotAddAnotherThirdParty(None, request)) {
+            Redirect(TaskListController.onPageLoad())
+          } else {
+            Redirect(
+              routes.ThirdPartyOrgDetailsController.onPageLoad(
+                Some(uuidGenerator.generate()),
+                mode,
+                returnTo
+              )
+            )
+          }
 
-        Ok(view(preparedFormAndId._2, preparedFormAndId._1, mode, returnTo))
+        case Some(existingId) =>
+          val preparedForm =
+            (for {
+              thirdParties <- request.journeyData.thirdPartyOrganisations.map(_.thirdParties)
+              thirdParty   <- thirdParties.find(_.id == existingId)
+              name         <- thirdParty.thirdPartyName
+              frn           = thirdParty.thirdPartyFrn
+            } yield form.fill(ThirdPartyOrgDetailsForm(name, frn)))
+              .getOrElse(form)
+
+          Ok(view(existingId, preparedForm, mode, returnTo))
       }
     }
 

--- a/test/controllers/liaisonofficers/LiaisonOfficerNameControllerSpec.scala
+++ b/test/controllers/liaisonofficers/LiaisonOfficerNameControllerSpec.scala
@@ -62,21 +62,20 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
 
     "must return OK and the correct view for a GET when an id is provided and no existing answer is found" in {
 
-      when(mockUuidGenerator.generate()).thenReturn(generatedId)
-
-      val application = applicationBuilder(journeyData = Some(emptyJourneyData))
-        .overrides(bind[UuidGenerator].toInstance(mockUuidGenerator))
-        .build()
+      val application =
+        applicationBuilder(journeyData = Some(emptyJourneyData))
+          .build()
 
       running(application) {
-        val request = FakeRequest(GET, LiaisonOfficerNameController.onPageLoad(Some(existingId), NormalMode).url)
+        val request =
+          FakeRequest(GET, LiaisonOfficerNameController.onPageLoad(Some(existingId), NormalMode).url)
 
         val result = route(application, request).value
 
         val view = application.injector.instanceOf[LiaisonOfficerNameView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, NormalMode, None)(
+        contentAsString(result) mustEqual view(existingId, form, NormalMode, None)(
           request,
           messages(application)
         ).toString
@@ -116,7 +115,7 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
       }
     }
 
-    "must return OK and the correct view for a GET when no id is provided" in {
+    "must redirect to canonical URL when no id is provided" in {
 
       when(mockUuidGenerator.generate()).thenReturn(generatedId)
 
@@ -126,17 +125,20 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
           .build()
 
       running(application) {
-        val request = FakeRequest(GET, LiaisonOfficerNameController.onPageLoad(None, NormalMode).url)
+        val request =
+          FakeRequest(
+            GET,
+            LiaisonOfficerNameController.onPageLoad(None, NormalMode).url
+          )
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[LiaisonOfficerNameView]
+        status(result) mustEqual SEE_OTHER
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, NormalMode, None)(
-          request,
-          messages(application)
-        ).toString
+        redirectLocation(result).value mustEqual
+          LiaisonOfficerNameController
+            .onPageLoad(Some(generatedId), NormalMode)
+            .url
       }
     }
 
@@ -638,10 +640,7 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
     }
 
     "must render view with CheckMode on a GET" in {
-      when(mockUuidGenerator.generate()).thenReturn(generatedId)
-
       val application = applicationBuilder(journeyData = Some(emptyJourneyData))
-        .overrides(bind[UuidGenerator].toInstance(mockUuidGenerator))
         .build()
 
       running(application) {
@@ -652,7 +651,7 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[LiaisonOfficerNameView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, CheckMode, None)(
+        contentAsString(result) mustEqual view(existingId, form, CheckMode, None)(
           request,
           messages(application)
         ).toString

--- a/test/controllers/liaisonofficers/LiaisonOfficerNameControllerSpec.scala
+++ b/test/controllers/liaisonofficers/LiaisonOfficerNameControllerSpec.scala
@@ -198,30 +198,6 @@ class LiaisonOfficerNameControllerSpec extends SpecBase {
       }
     }
 
-    "must redirect to task list on GET when an unknown liaison officer id is provided and the maximum number has been reached" in {
-
-      val journeyData =
-        JourneyData(
-          groupId = testGroupId,
-          enrolmentId = testString,
-          liaisonOfficers = Some(
-            LiaisonOfficers(liaisonOfficers(maxLiaisonOfficers))
-          )
-        )
-
-      val application = applicationBuilder(journeyData = Some(journeyData)).build()
-
-      running(application) {
-        val request =
-          FakeRequest(GET, LiaisonOfficerNameController.onPageLoad(Some("unknown-id"), NormalMode).url)
-
-        val result = route(application, request).value
-
-        status(result) mustEqual SEE_OTHER
-        redirectLocation(result).value mustEqual TaskListController.onPageLoad().url
-      }
-    }
-
     "must return BadRequest and errors when invalid data is submitted" in {
 
       val application = applicationBuilder(journeyData = Some(emptyJourneyData)).build()

--- a/test/controllers/signatories/SignatoryNameControllerSpec.scala
+++ b/test/controllers/signatories/SignatoryNameControllerSpec.scala
@@ -61,7 +61,7 @@ class SignatoryNameControllerSpec extends SpecBase {
         .build()
 
       running(application) {
-        val request = FakeRequest(GET, SignatoryNameController.onPageLoad(Some(existingId), NormalMode).url)
+        val request = FakeRequest(GET, SignatoryNameController.onPageLoad(Some(generatedId), NormalMode).url)
 
         val result = route(application, request).value
 
@@ -108,7 +108,7 @@ class SignatoryNameControllerSpec extends SpecBase {
       }
     }
 
-    "must return OK and the correct view for a GET when no id is provided" in {
+    "must redirect to canonical URL when no id is provided" in {
 
       when(mockUuidGenerator.generate()).thenReturn(generatedId)
 
@@ -118,17 +118,15 @@ class SignatoryNameControllerSpec extends SpecBase {
           .build()
 
       running(application) {
-        val request = FakeRequest(GET, SignatoryNameController.onPageLoad(None, NormalMode).url)
+        val request =
+          FakeRequest(GET, SignatoryNameController.onPageLoad(None, NormalMode, None).url)
 
         val result = route(application, request).value
 
-        val view = application.injector.instanceOf[SignatoryNameView]
+        status(result) mustEqual SEE_OTHER
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, NormalMode, None)(
-          request,
-          messages(application)
-        ).toString
+        redirectLocation(result).value mustEqual
+          SignatoryNameController.onPageLoad(Some(generatedId), NormalMode, None).url
       }
     }
 
@@ -301,10 +299,7 @@ class SignatoryNameControllerSpec extends SpecBase {
     }
 
     "must render view with CheckMode on a GET" in {
-      when(mockUuidGenerator.generate()).thenReturn(generatedId)
-
       val application = applicationBuilder(journeyData = Some(emptyJourneyData))
-        .overrides(bind[UuidGenerator].toInstance(mockUuidGenerator))
         .build()
 
       running(application) {
@@ -315,7 +310,7 @@ class SignatoryNameControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[SignatoryNameView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, CheckMode, None)(
+        contentAsString(result) mustEqual view(existingId, form, CheckMode, None)(
           request,
           messages(application)
         ).toString
@@ -506,6 +501,7 @@ class SignatoryNameControllerSpec extends SpecBase {
         redirectLocation(result).value mustEqual TaskListController.onPageLoad().url
       }
     }
+
     "must allow access when below max signatories and no id is provided" in {
 
       val max = 3
@@ -535,7 +531,16 @@ class SignatoryNameControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
-        status(result) mustEqual OK
+        status(result) mustEqual SEE_OTHER
+
+        val redirectUrl = redirectLocation(result).value
+
+        redirectUrl mustEqual
+          SignatoryNameController.onPageLoad(Some(generatedId), NormalMode, None).url
+
+        redirectUrl must not equal TaskListController.onPageLoad().url
+
+        verify(mockUuidGenerator, atMostOnce).generate()
       }
     }
   }

--- a/test/controllers/thirdparty/ThirdPartyOrgDetailsControllerSpec.scala
+++ b/test/controllers/thirdparty/ThirdPartyOrgDetailsControllerSpec.scala
@@ -64,7 +64,7 @@ class ThirdPartyOrgDetailsControllerSpec extends SpecBase {
 
       running(application) {
         val request =
-          FakeRequest(GET, ThirdPartyOrgDetailsController.onPageLoad(Some(existingId), NormalMode, None).url)
+          FakeRequest(GET, ThirdPartyOrgDetailsController.onPageLoad(Some(generatedId), NormalMode, None).url)
 
         val result = route(application, request).value
 
@@ -75,6 +75,47 @@ class ThirdPartyOrgDetailsControllerSpec extends SpecBase {
           request,
           messages(application)
         ).toString
+      }
+    }
+
+    "must redirect to canonical URL when no id is provided and below max third parties" in {
+
+      val generatedId = "generated-id-123"
+      val max         = 2
+
+      val journeyData =
+        JourneyData(
+          groupId = testGroupId,
+          enrolmentId = testString,
+          thirdPartyOrganisations = Some(
+            ThirdPartyOrganisations(
+              None,
+              Seq(
+                ThirdParty("id-1", Some("Old Name"), thirdPartyFrn = Some("123456"))
+              ),
+              Seq.empty
+            )
+          )
+        )
+
+      when(mockUuidGenerator.generate()).thenReturn(generatedId)
+
+      val application =
+        applicationBuilder(journeyData = Some(journeyData))
+          .overrides(bind[UuidGenerator].toInstance(mockUuidGenerator))
+          .configure("max-third-parties" -> max)
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(GET, ThirdPartyOrgDetailsController.onPageLoad(None, NormalMode, None).url)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual
+          ThirdPartyOrgDetailsController.onPageLoad(Some(generatedId), NormalMode, None).url
       }
     }
 
@@ -331,12 +372,8 @@ class ThirdPartyOrgDetailsControllerSpec extends SpecBase {
     }
 
     "must render CheckMode view" in {
-
-      when(mockUuidGenerator.generate()).thenReturn(generatedId)
-
       val application =
         applicationBuilder(journeyData = Some(emptyJourneyData))
-          .overrides(bind[UuidGenerator].toInstance(mockUuidGenerator))
           .build()
 
       running(application) {
@@ -348,7 +385,7 @@ class ThirdPartyOrgDetailsControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[ThirdPartyOrgDetailsView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(generatedId, form, CheckMode, None)(
+        contentAsString(result) mustEqual view(existingId, form, CheckMode, None)(
           request,
           messages(application)
         ).toString


### PR DESCRIPTION
This change introduces a canonical redirect behaviour when **id = None** on onPageLoad.

Why this change was introduced. Previously, the controller would:

- generate a UUID internally when id = None
- render the page directly using that generated ID

This meant the URL in the browser did not reliably reflect the persisted entity identifier

**What has changed:**

Now, when id = None:

- If the user has reached the maximum number of liaison officers → redirect to Task List
- If the user can still add another officer → redirect to a canonical URL


The Some(id) behaviour remains unchanged